### PR TITLE
Delay before respawning mpg process.

### DIFF
--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:           hmp3-ng
-version:        2.16.0
+version:        2.16.1
 synopsis:       A 2019 fork of an ncurses mp3 player written in Haskell
 description:    An mp3 player with a curses frontend.  Playlists are populated by
                 passing file and directory names on the command line.  'h' displays


### PR DESCRIPTION
Closes #28.  This moves the respawn delay so that an immediate crash is delayed instead of only a failed fork.  This prevents process-spawning at full throttle when the sub-process runs but immediately fails, which can happen for any number of reasons.  This is probably the cause of behavior in the linked issue.