### PR TITLE
Hopeful fix for spinning on terminal crash.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -271,10 +271,8 @@ mpgInput field = runForever $ do
 run :: IO ()
 run = runForever $ sequence_ . keymap =<< getKeys
   where
-    getKeys = unsafeInterleaveIO $ do
-            c  <- UI.getKey
-            cs <- getKeys
-            pure (c:cs) -- A lazy list of curses keys
+    -- A lazy list of curses keys
+    getKeys = unsafeInterleaveIO $ (:) <$> UI.getKey <*> getKeys
 
 ------------------------------------------------------------------------
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -33,7 +33,7 @@
 module Keymap where
 
 import Prelude ()
-import Base hiding (all, delete)
+import Base hiding (all, delete, (!?))
 
 import Core
 import Config       (package)

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:           hmp3-ng
-version:        2.17.0
+version:        2.17.1
 synopsis:       A 2019 fork of an ncurses mp3 player written in Haskell
 description:    An mp3 player with a curses frontend.  Playlists are populated by
                 passing file and directory names on the command line.  'h' displays

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.9
+resolver: lts-23.28
 system-ghc: true
 compiler-check: newer-minor
 


### PR DESCRIPTION
Closes #28 (again, hopefully for real this time).

This may be somewhat hacky, but if the read from the terminal fails with an error, then instead of repeatedly trying, the process immediately exits.  This is tested and verified to fix this problem.  It may not be that the key query loop is the cause of the high CPU (when I delay before retrying I still get 100% CPU usage), but this change does prevent it.

I don't think we would get an error from `getch` under ordinary conditions, so I'm hoping this won't cause random crashes.  (I'm going to leave it running for a while before merging this.)