### PR TITLE
Drop AmbiString; UTF-8 ByteString everywhere on the display path.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -40,7 +40,6 @@ import Text.Regex.PCRE.Light
 import {-# SOURCE #-} Keymap (keyLoop)
 
 import qualified Data.ByteString.Char8 as P
-import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Sequence as Seq
 
 import Data.Array               ((!), bounds, Array)
@@ -535,8 +534,7 @@ showHist = do
         helpVisible = False,
         histVisible = Just $ do
             (tm, ix) <- toList $ playHist st
-            pure (UTF8.toString $ showTimeDiff_ True tm now
-                , (ix, UTF8.toString $ fbase $ music st ! ix))
+            pure (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
         }
 
 -- | Toggle the mode flag

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 -- Copyright (c) 2004-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2008, 2019-2026 Galen Huntington

--- a/State.hs
+++ b/State.hs
@@ -48,7 +48,7 @@ data HState = HState {
        ,status          :: !Status
        ,minibuffer      :: !StringA              -- contents of minibuffer
        ,helpVisible     :: !Bool                 -- is the help window shown?
-       ,histVisible     :: !(Maybe [(String, (Int, String))]) -- history pop-up if shown
+       ,histVisible     :: !(Maybe [(ByteString, (Int, ByteString))]) -- history pop-up if shown
        ,exitVisible     :: !Bool                 -- confirm exit modal shown
        ,miniFocused     :: !Bool                 -- is the mini buffer focused?
        ,mode            :: !Mode                 -- random mode

--- a/Style.hs
+++ b/Style.hs
@@ -39,16 +39,14 @@ data Color
     deriving stock (Eq,Ord)
 
 -- | Foreground and background color pairs
-data Style = Style !Color !Color 
+data Style = Style !Color !Color
     deriving stock (Eq,Ord)
 
--- | Can hold an optimized ByteString or a Unicode String.
-data AmbiString = B !ByteString | U !String
-
--- | A list of such values (the representation is optimised)
-data StringA 
+-- | A list of styled UTF-8 ByteString segments making up one line.
+-- 'Fast' is the single-segment fast path; 'FancyS' is a multi-segment line.
+data StringA
     = Fast   {-# UNPACK #-} !ByteString {-# UNPACK #-} !Style
-    | FancyS ![(AmbiString,Style)]  -- one line made up of segments
+    | FancyS ![(ByteString, Style)]
 
 ------------------------------------------------------------------------
 --

--- a/Style.hs
+++ b/Style.hs
@@ -1,5 +1,5 @@
 -- Copyright (c) 2004-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
--- Copyright (c) 2019-2022 Galen Huntington
+-- Copyright (c) 2019-2022, 2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
 --

--- a/UI.hs
+++ b/UI.hs
@@ -28,7 +28,7 @@ import Tree                     (File(fdir, fbase), Dir(dname))
 import State
 import Syntax
 import Config
-import Width                    (displayWidth, ellipsize, forceWidth)
+import Width                    (displayWidth, toMaxWidth, toWidth)
 import qualified UI.HSCurses.Curses as Curses
 import {-# SOURCE #-} Keymap    (keyTable, unkey, charToKey)
 
@@ -261,7 +261,7 @@ instance Element PPlaying where
         PId3 a  = draw dd
         PInfo b = draw dd
         line | gap >= 0 = a : spaces gap : right
-             | True     = ellipsize lim a : right
+             | True     = toMaxWidth lim a : right
             where lim = x - 5 - (if showId3 then P.length b else -1)
                   gap = lim - displayWidth a
                   showId3 = x > 59
@@ -292,29 +292,28 @@ instance ModalElement HelpModal where
     drawModal sty swd st = do
         guard $ helpVisible st
         pure (wd, [ Fast (f cs h) sty | (h, cs, _) <- keyTable ])
-        where
-            wd = modalWidth swd
-            f :: [Char] -> String -> ByteString
-            f cs ps = forceWidth wd
-                        $ forceWidth clen cmds <> u ps where
-                clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
-                cmds = P.unwords ("" : map pprIt cs)
-                pprIt c = case c of
-                      '\n' -> "Enter"
-                      '\f' -> "^L"
-                      '\\' -> "\\"
-                      ' '  -> "Space"
-                      _ -> case charToKey c of
-                        Curses.KeyUp        -> u"↑"
-                        Curses.KeyDown      -> u"↓"
-                        Curses.KeyPPage     -> "PgUp"
-                        Curses.KeyNPage     -> "PgDn"
-                        Curses.KeyLeft      -> u"←"
-                        Curses.KeyRight     -> u"→"
-                        Curses.KeyEnd       -> "End"
-                        Curses.KeyHome      -> "Home"
-                        Curses.KeyBackspace -> "Backspace"
-                        _ -> u[c]
+      where
+        wd = modalWidth swd
+        f :: [Char] -> String -> ByteString
+        f cs ps = toWidth wd $ toWidth clen cmds <> u ps where
+            clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
+            cmds = P.unwords ("" : map pprIt cs)
+            pprIt c = case c of
+                  '\n' -> "Enter"
+                  '\f' -> "^L"
+                  '\\' -> "\\"
+                  ' '  -> "Space"
+                  _ -> case charToKey c of
+                    Curses.KeyUp        -> u"↑"
+                    Curses.KeyDown      -> u"↓"
+                    Curses.KeyPPage     -> "PgUp"
+                    Curses.KeyNPage     -> "PgDn"
+                    Curses.KeyLeft      -> u"←"
+                    Curses.KeyRight     -> u"→"
+                    Curses.KeyEnd       -> "End"
+                    Curses.KeyHome      -> "Home"
+                    Curses.KeyBackspace -> "Backspace"
+                    _ -> u[c]
 
 ------------------------------------------------------------------------
 
@@ -324,8 +323,8 @@ instance ModalElement HistModal where
             mtlen = maximum $ map (displayWidth . fst) hist
             tlen = min (mtlen + 1) $ wd `div` 3
         (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
-            let tstr = ellipsize tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
-            in Fast (forceWidth wd $ " " <> P.singleton c <> " " <> tstr <> " " <> song) sty
+            let tstr = toMaxWidth tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
+            in Fast (toWidth wd $ " " <> P.singleton c <> " " <> tstr <> " " <> song) sty
 
 ------------------------------------------------------------------------
 
@@ -333,9 +332,9 @@ instance ModalElement ExitModal where
     drawModal sty swd st = do
         guard $ exitVisible st
         let wd = modalWidth swd `min` 19
-            blank = Fast (forceWidth wd "") sty
+            blank = Fast (toWidth wd "") sty
             padl = P.replicate ((wd - 9) `div` 2) ' '
-            msg = forceWidth wd $ padl <> "Exit (y)?"
+            msg = toWidth wd $ padl <> "Exit (y)?"
         pure (wd, [blank, Fast msg sty, blank])
 
 ------------------------------------------------------------------------
@@ -505,7 +504,7 @@ instance Element PlayList where
                 loop _ []     = []
                 loop n (v:vs) =
                     let r = if fdir v > n then Just (fdir v) else Nothing
-                    in (r, ellipsize (x - indent - 1) $ fbase v)
+                    in (r, toMaxWidth (x - indent - 1) $ fbase v)
                             : loop (fdir v) vs
 
             list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
@@ -537,7 +536,7 @@ instance Element PlayList where
                 : map (, sty) v
               where
                 sty' = if sty == sty2 || sty == sty3 then sty2 else sty1
-                d = ellipsize (indent - 1) $ basenameP
+                d = toMaxWidth (indent - 1) $ basenameP
                         $ case size st of
                             0 -> "(empty)"
                             _ -> dname $ folders st ! i

--- a/UI.hs
+++ b/UI.hs
@@ -31,6 +31,7 @@ import Tree                     (File(fdir, fbase), Dir(dname))
 import State
 import Syntax
 import Config
+import Width                    (displayWidth, ellipsize, forceWidth)
 import qualified UI.HSCurses.Curses as Curses
 import {-# SOURCE #-} Keymap    (keyTable, unkey, charToKey)
 
@@ -510,7 +511,7 @@ instance Element PlayList where
                 loop _ []     = []
                 loop n (v:vs) =
                     let r = if fdir v > n then Just (fdir v) else Nothing
-                    in (r, ellipsize (x - indent - 1) (fbase v))
+                    in (r, ellipsize (x - indent - 1) $ fbase v)
                             : loop (fdir v) vs
 
             list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
@@ -717,45 +718,6 @@ setXterm s = setXtermTitle $ case status s of
                         else [": ", id3title ti]
     Paused  -> ["paused"]
     Stopped -> ["stopped"]
-
--- | Sum of the column widths of every codepoint in a UTF-8 ByteString.
-displayWidth :: ByteString -> Int
-displayWidth = UTF8.foldr (\c acc -> charWidth c + acc) 0
-
--- | UTF-8-aware ellipsize/forceWidth.  If 'pad' is True the result is padded
--- with trailing spaces to exactly 'w' columns; otherwise the input is
--- returned unchanged when it already fits.  When it does not fit, the
--- largest UTF-8 prefix whose total column width is < w is taken, and the
--- remaining columns are filled with ellipsis characters.
-sizer :: Bool -> Int -> ByteString -> ByteString
-sizer pad w bs
-    | dw <= w   = if pad then bs <> P.replicate (w - dw) ' ' else bs
-    | otherwise = walk 0 bs
-  where
-    dw = displayWidth bs
-    walk !l rest = case UTF8.uncons rest of
-        Nothing -> bs <> ellipses (w - l)   -- unreachable: dw > w
-        Just (c, rest') ->
-            let l' = l + charWidth c
-            in if l' > w - 1
-                then P.take (P.length bs - P.length rest) bs
-                        <> ellipses (w - l)
-                else walk l' rest'
-
-    ellipses k = mconcat (replicate k ellipsis)
-
-ellipsis :: ByteString
-ellipsis = UTF8.fromString "…"
-
-ellipsize, forceWidth :: Int -> ByteString -> ByteString
-ellipsize  = sizer False
-forceWidth = sizer True
-
-charWidth :: Char -> Int
-charWidth = fromIntegral . wcwidth . toEnum . fromEnum
-
-foreign import ccall safe
-    wcwidth :: CWchar -> CInt
 
 --  Not exported by hscurses.
 foreign import ccall safe

--- a/UI.hs
+++ b/UI.hs
@@ -299,11 +299,11 @@ instance ModalElement HelpModal where
             clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
             cmds = P.unwords ("" : map pprIt cs)
             pprIt c = case c of
-                  '\n' -> "Enter"
-                  '\f' -> "^L"
-                  '\\' -> "\\"
-                  ' '  -> "Space"
-                  _ -> case charToKey c of
+                '\n' -> "Enter"
+                '\f' -> "^L"
+                '\\' -> "\\"
+                ' '  -> "Space"
+                _ -> case charToKey c of
                     Curses.KeyUp        -> u"↑"
                     Curses.KeyDown      -> u"↓"
                     Curses.KeyPPage     -> "PgUp"

--- a/UI.hs
+++ b/UI.hs
@@ -44,7 +44,6 @@ import Foreign.C.Types
 import Foreign.C.Error (Errno(..), getErrno)
 
 import qualified Data.ByteString.Char8 as P
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.UTF8 as UTF8
 
@@ -259,13 +258,12 @@ instance Element PPlaying where
         x       = sizeW $ drawSize dd
         PId3 a  = draw dd
         PInfo b = draw dd
-        s       = UTF8.toString a
-        line | gap >= 0 = U s : B (spaces gap) : right
-             | True     = U (ellipsize lim s) : right
+        line | gap >= 0 = a : spaces gap : right
+             | True     = ellipsize lim a : right
             where lim = x - 5 - (if showId3 then P.length b else -1)
-                  gap = lim - displayWidth s
+                  gap = lim - displayWidth a
                   showId3 = x > 59
-                  right = if showId3 then [B " ", B b] else []
+                  right = if showId3 then [" ", b] else []
 
 -- | Id3 Info
 instance Element PId3 where
@@ -284,8 +282,8 @@ instance Element PInfo where
 emptyVal :: ByteString
 emptyVal = "(empty)"
 
-spc2 :: AmbiString
-spc2 = B $ spaces 2
+spc2 :: ByteString
+spc2 = spaces 2
 
 modalWidth :: Int -> Int
 modalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
@@ -301,37 +299,37 @@ instance ModalElement HelpModal where
         where
             wd = modalWidth swd
             f :: [Char] -> String -> ByteString
-            f cs ps = UTF8.fromString $ forceWidth wd
-                        $ forceWidth clen cmds <> ps where
+            f cs ps = forceWidth wd
+                        $ forceWidth clen cmds <> UTF8.fromString ps where
                 clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
-                cmds = unwords $ "" : map pprIt cs
+                cmds = P.unwords ("" : map pprIt cs)
                 pprIt c = case c of
-                      '\n'            -> "Enter"
-                      '\f'            -> "^L"
-                      '\\'            -> "\\"
-                      ' '             -> "Space"
+                      '\n' -> "Enter"
+                      '\f' -> "^L"
+                      '\\' -> "\\"
+                      ' '  -> "Space"
                       _ -> case charToKey c of
-                        Curses.KeyUp    -> "↑"
-                        Curses.KeyDown  -> "↓"
-                        Curses.KeyPPage -> "PgUp"
-                        Curses.KeyNPage -> "PgDn"
-                        Curses.KeyLeft  -> "←"
-                        Curses.KeyRight -> "→"
-                        Curses.KeyEnd   -> "End"
-                        Curses.KeyHome  -> "Home"
+                        Curses.KeyUp        -> UTF8.fromString "↑"
+                        Curses.KeyDown      -> UTF8.fromString "↓"
+                        Curses.KeyPPage     -> "PgUp"
+                        Curses.KeyNPage     -> "PgDn"
+                        Curses.KeyLeft      -> UTF8.fromString "←"
+                        Curses.KeyRight     -> UTF8.fromString "→"
+                        Curses.KeyEnd       -> "End"
+                        Curses.KeyHome      -> "Home"
                         Curses.KeyBackspace -> "Backspace"
-                        _ -> [c]
+                        _ -> UTF8.fromString [c]
 
 ------------------------------------------------------------------------
 
 instance ModalElement HistModal where
     drawModal sty swd st = flip fmap (histVisible st) \hist -> do
         let wd = modalWidth swd
-            mtlen = maximum $ map (length . fst) hist
+            mtlen = maximum $ map (displayWidth . fst) hist
             tlen = min (mtlen + 1) $ wd `div` 3
         (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
-            let tstr = ellipsize tlen $ replicate (tlen - displayWidth time) ' ' ++ time
-            in Fast (UTF8.fromString $ forceWidth wd $ ' ' : c : ' ' : tstr ++ ' ' : song) sty
+            let tstr = ellipsize tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
+            in Fast (forceWidth wd $ " " <> P.singleton c <> " " <> tstr <> " " <> song) sty
 
 ------------------------------------------------------------------------
 
@@ -339,10 +337,10 @@ instance ModalElement ExitModal where
     drawModal sty swd st = do
         guard $ exitVisible st
         let wd = modalWidth swd `min` 19
-            blank = Fast (UTF8.fromString $ forceWidth wd "") sty
-            padl = replicate ((wd - 9) `div` 2) ' '
-            msg = forceWidth wd $ padl ++ "Exit (y)?"
-        pure (wd, [blank, Fast (UTF8.fromString msg) sty, blank])
+            blank = Fast (forceWidth wd "") sty
+            padl = P.replicate ((wd - 9) `div` 2) ' '
+            msg = forceWidth wd $ padl <> "Exit (y)?"
+        pure (wd, [blank, Fast msg sty, blank])
 
 ------------------------------------------------------------------------
 
@@ -351,9 +349,9 @@ instance Element PTimes where
     draw DD { drawFrame=Just Frame {..}, drawSize=Size{sizeW=x} } =
         PTimes $ FancyS $ map (, defaultSty)
             if x - 4 < P.length elapsed
-            then [B " "]
-            else [spc2, B elapsed]
-                    ++ (guard (distance > 0) *> [B gap, B remaining])
+            then [" "]
+            else [spc2, elapsed]
+                    ++ (guard (distance > 0) *> [gap, remaining])
       where
         elapsed   = P.pack $ printf "%d:%02d" l_m l_s
         remaining = P.pack $ printf "-%d:%02d" r_m r_s
@@ -371,15 +369,15 @@ instance Element PTimes where
 instance Element ProgressBar where
     draw dd@DD{drawSize=Size{sizeW=w}, drawState=st} = case drawFrame dd of
       Nothing -> ProgressBar . FancyS $
-              [(spc2,defaultSty) ,(B $ spaces (w-4), bgs)]
-        where 
+              [(spc2, defaultSty), (spaces (w-4), bgs)]
+        where
           (Style _ bg) = progress (config st)
           bgs          = Style bg bg
       Just Frame {..} -> ProgressBar . FancyS $
           [(spc2, defaultSty)
-          ,(B $ spaces distance, fgs)
-          ,(B $ spaces (width - distance), bgs)]
-        where 
+          ,(spaces distance, fgs)
+          ,(spaces (width - distance), bgs)]
+        where
           width    = w - 4
           total    = curr + left
           distance = round ((curr / total) * fromIntegral width)
@@ -452,17 +450,18 @@ instance Element PlayTitle where
     draw dd =
         PlayTitle $ FancyS $ map (,hl)
             if gap >= 2
-            then [B $ mconcat [space,inf,spaces gapl], U modes,
-                    B $ mconcat [spaces gapr,time,space,ver,space]]
+            then [mconcat [space,inf,spaces gapl], modesBS,
+                    mconcat [spaces gapr,time,space,ver,space]]
             else let gap' = x - modlen; gapl' = gap' `div` 2
                  in if gap' >= 2
-                    then [B $ spaces gapl', U modes, B $ spaces $ gap' - gapl']
-                    else [B space, U $ take (x-2) modes, B space]
+                    then [spaces gapl', modesBS, spaces $ gap' - gapl']
+                    else [space, UTF8.fromString (take (x-2) modes), space]
       where
         PlayInfo inf    = draw dd
         PTime time      = draw dd
         PlayModes modes = draw dd
         PVersion ver    = draw dd
+        modesBS         = UTF8.fromString modes
 
         x       = sizeW $ drawSize dd
         lsize   = 1 + P.length inf
@@ -506,45 +505,44 @@ instance Element PlayList where
                 where off = screens * buflen
 
             -- TODO rewrite as fold
-            visible' :: [(Maybe Int, String)]
+            visible' :: [(Maybe Int, ByteString)]
             visible' = loop (-1) visible where
                 loop _ []     = []
                 loop n (v:vs) =
                     let r = if fdir v > n then Just (fdir v) else Nothing
-                    in (r, ellipsize (x - indent - 1) $ UTF8.toString $ fbase v)
+                    in (r, ellipsize (x - indent - 1) (fbase v))
                             : loop (fdir v) vs
 
             list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
             indent = (round $ (0.334 :: Float) * fromIntegral x) :: Int
-                
-            color :: ((Maybe Int, String), Int)
-                        -> (Maybe Int, Style, [AmbiString])
-            color ((m,s),i) 
+
+            color :: ((Maybe Int, ByteString), Int)
+                        -> (Maybe Int, Style, [ByteString])
+            color ((m,s),i)
                 | i == select && i == playing = f sty3
                 | i == select                 = f sty2
                 | i == playing                = f sty1
-                | otherwise                   = (m, defaultSty, [U s])
+                | otherwise                   = (m, defaultSty, [s])
                 where
-                    f sty = (m, sty, [
-                        U s,
-                        B $ spaces (x - indent - 1 - displayWidth s)])
-            
+                    f sty = (m, sty,
+                        [s, spaces (x - indent - 1 - displayWidth s)])
+
             sty1 = selected . config $ st
             sty2 = cursors  . config $ st
             sty3 = combined . config $ st
 
-            drawIt :: (Maybe Int, Style, [AmbiString]) -> StringA
+            drawIt :: (Maybe Int, Style, [ByteString]) -> StringA
             drawIt (Nothing, sty, v) =
-                FancyS $ map (, sty) $ B (spaces (1 + indent)) : v
+                FancyS $ map (, sty) $ spaces (1 + indent) : v
 
             drawIt (Just i, sty, v) = FancyS
-                $ (U d, sty')
-                : (B $ spaces (indent + 1 - displayWidth d), sty')
+                $ (d, sty')
+                : (spaces (indent + 1 - displayWidth d), sty')
                 : map (, sty) v
               where
                 sty' = if sty == sty2 || sty == sty3 then sty2 else sty1
-                d = ellipsize (indent - 1) $ UTF8.toString $ basenameP
+                d = ellipsize (indent - 1) $ basenameP
                         $ case size st of
                             0 -> "(empty)"
                             _ -> dname $ folders st ! i
@@ -643,16 +641,15 @@ redraw = Draw $ discardErrors do
 -- | Draw a coloured (or not) string to the screen
 --
 drawLine :: Int -> StringA -> IO ()
-drawLine _ (Fast ps sty) = drawAmbiString (B ps) sty
-drawLine _ (FancyS ls) = traverse_ (uncurry drawAmbiString) ls
+drawLine _ (Fast ps sty) = drawSegment ps sty
+drawLine _ (FancyS ls)   = traverse_ (uncurry drawSegment) ls
 
-drawAmbiString :: AmbiString -> Style -> IO ()
-drawAmbiString as sty = withStyle sty $ case as of
-    -- Safe because C only reads the string.
-    B ps -> void $ B.unsafeUseAsCStringLen ps \ (cstr, len) ->
-                waddnstr Curses.stdScr cstr (fromIntegral len)
-    U s  -> Curses.wAddStr Curses.stdScr s
-{-# INLINE drawAmbiString #-}
+-- | Write a single styled UTF-8 segment.  Safe because C only reads the bytes.
+drawSegment :: ByteString -> Style -> IO ()
+drawSegment bs sty = withStyle sty $ void $
+    B.unsafeUseAsCStringLen bs \(cstr, len) ->
+        waddnstr Curses.stdScr cstr (fromIntegral len)
+{-# INLINE drawSegment #-}
 
 
 ------------------------------------------------------------------------
@@ -721,23 +718,37 @@ setXterm s = setXtermTitle $ case status s of
     Paused  -> ["paused"]
     Stopped -> ["stopped"]
 
-displayWidth :: String -> Int
-displayWidth = sum . map charWidth
+-- | Sum of the column widths of every codepoint in a UTF-8 ByteString.
+displayWidth :: ByteString -> Int
+displayWidth = UTF8.foldr (\c acc -> charWidth c + acc) 0
 
-sizer :: Bool -> Int -> String -> String
-sizer pad w s
-  | dw <= w = if pad then s ++ replicate (w - dw) ' ' else s
-  | True    = go 0 0 s where
-    go !i !l (c:s') =
-        if l' > w-1
-            then take i s ++ replicate (w-l) '…'
-            else go (i+1) l' s'
-      where l' = l + charWidth c
-    go _  _ _ = error "Should've been in first case!"
-    dw = displayWidth s
+-- | UTF-8-aware ellipsize/forceWidth.  If 'pad' is True the result is padded
+-- with trailing spaces to exactly 'w' columns; otherwise the input is
+-- returned unchanged when it already fits.  When it does not fit, the
+-- largest UTF-8 prefix whose total column width is < w is taken, and the
+-- remaining columns are filled with ellipsis characters.
+sizer :: Bool -> Int -> ByteString -> ByteString
+sizer pad w bs
+    | dw <= w   = if pad then bs <> P.replicate (w - dw) ' ' else bs
+    | otherwise = walk 0 bs
+  where
+    dw = displayWidth bs
+    walk !l rest = case UTF8.uncons rest of
+        Nothing -> bs <> ellipses (w - l)   -- unreachable: dw > w
+        Just (c, rest') ->
+            let l' = l + charWidth c
+            in if l' > w - 1
+                then P.take (P.length bs - P.length rest) bs
+                        <> ellipses (w - l)
+                else walk l' rest'
 
-ellipsize, forceWidth :: Int -> String -> String
-ellipsize = sizer False
+    ellipses k = mconcat (replicate k ellipsis)
+
+ellipsis :: ByteString
+ellipsis = UTF8.fromString "…"
+
+ellipsize, forceWidth :: Int -> ByteString -> ByteString
+ellipsize  = sizer False
 forceWidth = sizer True
 
 charWidth :: Char -> Int

--- a/UI.hs
+++ b/UI.hs
@@ -14,13 +14,10 @@
 
 module UI (
         runDraw,
-
         -- * Construction, destruction
         start, end, suspend, screenSize, refresh, refreshClock, resetui,
-
         -- * Input
         getKey
-
   )   where
 
 import Base
@@ -47,6 +44,10 @@ import Foreign.C.Error (Errno(..), getErrno)
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.UTF8 as UTF8
+
+
+u :: String -> ByteString
+u = UTF8.fromString -- write u-strings like it's Python 2
 
 
 newtype Draw = Draw (IO ())
@@ -254,7 +255,7 @@ instance (Element a, Element b) => Element (a,b) where
 -- Info about the current track
 instance Element PPlaying where
     draw dd =
-        PPlaying . FancyS $ map (, defaultSty) $ spc2 : line
+        PPlaying . FancyS $ map (, defaultSty) $ "  " : line
       where
         x       = sizeW $ drawSize dd
         PId3 a  = draw dd
@@ -271,20 +272,14 @@ instance Element PId3 where
     draw DD{drawState=st} = case id3 st of
         Just i  -> PId3 $ id3str i
         Nothing -> PId3 $ case size st of
-                                0 -> emptyVal
+                                0 -> "(empty)"
                                 _ -> fbase $ music st ! current st
 
 -- | mp3 information
 instance Element PInfo where
     draw DD{drawState=st} = PInfo case info st of
-        Nothing  -> emptyVal
+        Nothing  -> "(empty)"
         Just i   -> userinfo i
-
-emptyVal :: ByteString
-emptyVal = "(empty)"
-
-spc2 :: ByteString
-spc2 = spaces 2
 
 modalWidth :: Int -> Int
 modalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
@@ -301,7 +296,7 @@ instance ModalElement HelpModal where
             wd = modalWidth swd
             f :: [Char] -> String -> ByteString
             f cs ps = forceWidth wd
-                        $ forceWidth clen cmds <> UTF8.fromString ps where
+                        $ forceWidth clen cmds <> u ps where
                 clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
                 cmds = P.unwords ("" : map pprIt cs)
                 pprIt c = case c of
@@ -310,16 +305,16 @@ instance ModalElement HelpModal where
                       '\\' -> "\\"
                       ' '  -> "Space"
                       _ -> case charToKey c of
-                        Curses.KeyUp        -> UTF8.fromString "↑"
-                        Curses.KeyDown      -> UTF8.fromString "↓"
+                        Curses.KeyUp        -> u"↑"
+                        Curses.KeyDown      -> u"↓"
                         Curses.KeyPPage     -> "PgUp"
                         Curses.KeyNPage     -> "PgDn"
-                        Curses.KeyLeft      -> UTF8.fromString "←"
-                        Curses.KeyRight     -> UTF8.fromString "→"
+                        Curses.KeyLeft      -> u"←"
+                        Curses.KeyRight     -> u"→"
                         Curses.KeyEnd       -> "End"
                         Curses.KeyHome      -> "Home"
                         Curses.KeyBackspace -> "Backspace"
-                        _ -> UTF8.fromString [c]
+                        _ -> u[c]
 
 ------------------------------------------------------------------------
 
@@ -351,7 +346,7 @@ instance Element PTimes where
         PTimes $ FancyS $ map (, defaultSty)
             if x - 4 < P.length elapsed
             then [" "]
-            else [spc2, elapsed]
+            else ["  ", elapsed]
                     ++ (guard (distance > 0) *> [gap, remaining])
       where
         elapsed   = P.pack $ printf "%d:%02d" l_m l_s
@@ -370,12 +365,12 @@ instance Element PTimes where
 instance Element ProgressBar where
     draw dd@DD{drawSize=Size{sizeW=w}, drawState=st} = case drawFrame dd of
       Nothing -> ProgressBar . FancyS $
-              [(spc2, defaultSty), (spaces (w-4), bgs)]
+              [("  ", defaultSty), (spaces (w-4), bgs)]
         where
           (Style _ bg) = progress (config st)
           bgs          = Style bg bg
       Just Frame {..} -> ProgressBar . FancyS $
-          [(spc2, defaultSty)
+          [("  ", defaultSty)
           ,(spaces distance, fgs)
           ,(spaces (width - distance), bgs)]
         where
@@ -451,18 +446,18 @@ instance Element PlayTitle where
     draw dd =
         PlayTitle $ FancyS $ map (,hl)
             if gap >= 2
-            then [mconcat [space,inf,spaces gapl], modesBS,
-                    mconcat [spaces gapr,time,space,ver,space]]
+            then [mconcat [" ",inf,spaces gapl], modesBS,
+                    mconcat [spaces gapr,time," ",ver," "]]
             else let gap' = x - modlen; gapl' = gap' `div` 2
                  in if gap' >= 2
                     then [spaces gapl', modesBS, spaces $ gap' - gapl']
-                    else [space, UTF8.fromString (take (x-2) modes), space]
+                    else [" ", u $ take (x-2) modes, " "]
       where
         PlayInfo inf    = draw dd
         PTime time      = draw dd
         PlayModes modes = draw dd
         PVersion ver    = draw dd
-        modesBS         = UTF8.fromString modes
+        modesBS         = u modes
 
         x       = sizeW $ drawSize dd
         lsize   = 1 + P.length inf
@@ -472,7 +467,6 @@ instance Element PlayTitle where
         gapl    = 1 `max` ((side - lsize) `min` gap)
         gapr    = 1 `max` (gap - gapl)
         modlen  = 6 -- length modes
-        space   = spaces 1
         hl      = titlebar . config $ drawState dd
 
 -- | Playlist
@@ -650,7 +644,6 @@ drawSegment :: ByteString -> Style -> IO ()
 drawSegment bs sty = withStyle sty $ void $
     B.unsafeUseAsCStringLen bs \(cstr, len) ->
         waddnstr Curses.stdScr cstr (fromIntegral len)
-{-# INLINE drawSegment #-}
 
 
 ------------------------------------------------------------------------
@@ -719,7 +712,6 @@ setXterm s = setXtermTitle $ case status s of
     Paused  -> ["paused"]
     Stopped -> ["stopped"]
 
---  Not exported by hscurses.
 foreign import ccall safe
     waddnstr :: Curses.Window -> CString -> CInt -> IO CInt
 

--- a/UI.hs
+++ b/UI.hs
@@ -13,12 +13,12 @@
 --
 
 module UI (
-        runDraw,
-        -- * Construction, destruction
-        start, end, suspend, screenSize, refresh, refreshClock, resetui,
-        -- * Input
-        getKey
-  )   where
+    runDraw,
+    -- * Construction, destruction
+    start, end, suspend, screenSize, refresh, refreshClock, resetui,
+    -- * Input
+    getKey
+  ) where
 
 import Base
 
@@ -42,12 +42,13 @@ import Foreign.C.Types
 import Foreign.C.Error (Errno(..), getErrno)
 
 import qualified Data.ByteString.Char8 as P
-import qualified Data.ByteString.Unsafe as B
+import qualified Data.ByteString.Unsafe as P
 import qualified Data.ByteString.UTF8 as UTF8
 
 
+-- Write u-strings like it's Python 2.
 u :: String -> ByteString
-u = UTF8.fromString -- write u-strings like it's Python 2
+u = UTF8.fromString
 
 
 newtype Draw = Draw (IO ())
@@ -59,9 +60,7 @@ runDraw (Draw d) = withDrawLock d
 
 ------------------------------------------------------------------------
 
---
--- | how to initialise the ui
---
+-- | Initialize the UI
 start :: IO UIStyle
 start = do
     discardErrors do
@@ -247,7 +246,7 @@ printPlayScreen (PlayScreen (PPlaying a)
 
 ------------------------------------------------------------------------
 
-instance (Element a, Element b) => Element (a,b) where
+instance (Element a, Element b) => Element (a, b) where
     draw dd = (draw dd, draw dd)
 
 ------------------------------------------------------------------------
@@ -369,9 +368,9 @@ instance Element ProgressBar where
           (Style _ bg) = progress (config st)
           bgs          = Style bg bg
       Just Frame {..} -> ProgressBar . FancyS $
-          [("  ", defaultSty)
-          ,(spaces distance, fgs)
-          ,(spaces (width - distance), bgs)]
+          [ ("  ", defaultSty)
+          , (spaces distance, fgs)
+          , (spaces (width - distance), bgs)]
         where
           width    = w - 4
           total    = curr + left
@@ -445,8 +444,8 @@ instance Element PlayTitle where
     draw dd =
         PlayTitle $ FancyS $ map (,hl)
             if gap >= 2
-            then [mconcat [" ",inf,spaces gapl], modesBS,
-                    mconcat [spaces gapr,time," ",ver," "]]
+            then [mconcat [" ", inf, spaces gapl], modesBS,
+                    mconcat [spaces gapr, time, " ", ver, " "]]
             else let gap' = x - modlen; gapl' = gap' `div` 2
                  in if gap' >= 2
                     then [spaces gapl', modesBS, spaces $ gap' - gapl']
@@ -486,7 +485,7 @@ instance Element PlayList where
 
             -- number of screens down, and then offset
             buflen   = height - 2
-            (screens,select) = quotRem curr buflen -- keep cursor in screen
+            (screens, select) = quotRem curr buflen -- keep cursor in screen
 
             playing  = let top = screens * buflen
                            bot = (screens + 1) * buflen
@@ -586,7 +585,7 @@ renderModal st (Size h w) = do
        Curses.wMove Curses.stdScr voffset hoffset
        for_ (take mlines modal') \t -> do
             drawLine w t
-            (y',_) <- Curses.getYX Curses.stdScr
+            (y', _) <- Curses.getYX Curses.stdScr
             Curses.wMove Curses.stdScr (y'+1) hoffset
 
 renderModals :: HState -> Size -> IO ()
@@ -641,7 +640,7 @@ drawLine _ (FancyS ls)   = traverse_ (uncurry drawSegment) ls
 -- | Write a single styled UTF-8 segment.  Safe because C only reads the bytes.
 drawSegment :: ByteString -> Style -> IO ()
 drawSegment bs sty = withStyle sty $ void $
-    B.unsafeUseAsCStringLen bs \(cstr, len) ->
+    P.unsafeUseAsCStringLen bs \(cstr, len) ->
         waddnstr Curses.stdScr cstr (fromIntegral len)
 
 
@@ -674,7 +673,7 @@ gotoTop = Curses.wMove Curses.stdScr 0 0
 -- | Take a slice of an array efficiently
 slice :: Int -> Int -> Array Int e -> [e]
 slice i j arr = 
-    let (a,b) = bounds arr
+    let (a, b) = bounds arr
     in [unsafeAt arr n | n <- [max a i .. min b j] ]
 {-# INLINE slice #-}
 
@@ -710,6 +709,7 @@ setXterm s = setXtermTitle $ case status s of
                         else [": ", id3title ti]
     Paused  -> ["paused"]
     Stopped -> ["stopped"]
+
 
 foreign import ccall safe
     waddnstr :: Curses.Window -> CString -> CInt -> IO CInt

--- a/Width.hs
+++ b/Width.hs
@@ -1,0 +1,68 @@
+-- Copyright (c) 2004-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
+-- Copyright (c) 2019-2026 Galen Huntington
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- | Width-aware operations on UTF-8 'ByteString's, using libc 'wcwidth' to
+-- determine column widths.  Column counts therefore depend on the runtime
+-- locale; expect deterministic results only under a UTF-8 locale.
+module Width (
+    displayWidth,
+    ellipsize,
+    forceWidth,
+    charWidth,
+  ) where
+
+import Base
+
+import qualified Data.ByteString.Char8 as P
+import qualified Data.ByteString.UTF8 as UTF8
+
+import Foreign.C.Types
+
+
+-- | Sum of the column widths of every codepoint in a UTF-8 'ByteString'.
+displayWidth :: ByteString -> Int
+displayWidth = go 0 where
+    go !acc bs = case UTF8.uncons bs of
+        Nothing        -> acc
+        Just (c, rest) -> go (acc + charWidth c) rest
+
+-- | Truncate (with a trailing ellipsis) when the input does not fit in 'w'
+-- columns; pass it through unchanged otherwise.
+ellipsize :: Int -> ByteString -> ByteString
+ellipsize = sizer False
+
+-- | Like 'ellipsize', but pads short inputs with trailing spaces to 'w'
+-- columns exactly.
+forceWidth :: Int -> ByteString -> ByteString
+forceWidth = sizer True
+
+-- The two share an inner walker that finds the largest UTF-8 prefix whose
+-- column count is < w, then fills the remaining columns with ellipses.
+sizer :: Bool -> Int -> ByteString -> ByteString
+sizer pad w bs
+    | dw <= w   = if pad then bs <> P.replicate (w - dw) ' ' else bs
+    | otherwise = walk 0 bs
+  where
+    dw = displayWidth bs
+
+    walk !l rest = case UTF8.uncons rest of
+        -- Unreachable: dw > w means we always hit the truncation branch
+        -- before exhausting the input.  Fall back to the input as a safety
+        -- net so a faulty width invariant never crashes the UI.
+        Nothing -> bs
+        Just (c, rest') ->
+            let l' = l + charWidth c
+            in if l' > w - 1
+                then P.take (P.length bs - P.length rest) bs
+                        <> mconcat (replicate (w - l) ellipsis)
+                else walk l' rest'
+
+ellipsis :: ByteString
+ellipsis = UTF8.fromString "…"
+
+charWidth :: Char -> Int
+charWidth = fromIntegral . wcwidth . toEnum . fromEnum
+
+foreign import ccall safe
+    wcwidth :: CWchar -> CInt

--- a/Width.hs
+++ b/Width.hs
@@ -4,12 +4,7 @@
 -- | Width-aware operations on UTF-8 'ByteString's, using libc 'wcwidth' to
 -- determine column widths.  Column counts therefore depend on the runtime
 -- locale; expect deterministic results only under a UTF-8 locale.
-module Width (
-    displayWidth,
-    toMaxWidth,
-    toWidth,
-    charWidth,
-  ) where
+module Width (displayWidth, toMaxWidth, toWidth) where
 
 import Base
 
@@ -35,13 +30,10 @@ sizer pad w bs | dw <= w = if pad then bs <> P.replicate (w-dw) ' ' else bs
   where
     dw = displayWidth bs
     walk !l rest | l' >= w = P.take (P.length bs - P.length rest) bs
-                                <> mconcat (replicate (w-l) ellipsis)
+                                <> mconcat (replicate (w-l) $ UTF8.fromString "…")
                  | True    = walk l' rest'
-      where (c, rest') = fromJust $ UTF8.uncons rest
+      where (c, rest') = fromJust $ UTF8.uncons rest -- can't be at end since dw>w
             l' = l + charWidth c
-
-ellipsis :: ByteString
-ellipsis = UTF8.fromString "…"
 
 charWidth :: Char -> Int
 charWidth = fromIntegral . wcwidth . toEnum . fromEnum

--- a/Width.hs
+++ b/Width.hs
@@ -6,8 +6,8 @@
 -- locale; expect deterministic results only under a UTF-8 locale.
 module Width (
     displayWidth,
-    ellipsize,
-    forceWidth,
+    toMaxWidth,
+    toWidth,
     charWidth,
   ) where
 
@@ -24,10 +24,10 @@ displayWidth :: ByteString -> Int
 displayWidth = UTF8.foldl (\acc c -> acc + charWidth c) 0
 
 -- | These functions truncate with ellipses if needed to get width ≤'w'.
--- 'forceWidth' adds padding as needed so the width is exactly 'w'.
-ellipsize, forceWidth :: Int -> ByteString -> ByteString
-ellipsize = sizer False
-forceWidth = sizer True
+-- 'toWidth' adds padding as needed so the width is exactly 'w'.
+toMaxWidth, toWidth :: Int -> ByteString -> ByteString
+toMaxWidth = sizer False
+toWidth = sizer True
 
 sizer :: Bool -> Int -> ByteString -> ByteString
 sizer pad w bs | dw <= w = if pad then bs <> P.replicate (w-dw) ' ' else bs

--- a/Width.hs
+++ b/Width.hs
@@ -1,4 +1,3 @@
--- Copyright (c) 2004-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -22,41 +21,24 @@ import Foreign.C.Types
 
 -- | Sum of the column widths of every codepoint in a UTF-8 'ByteString'.
 displayWidth :: ByteString -> Int
-displayWidth = go 0 where
-    go !acc bs = case UTF8.uncons bs of
-        Nothing        -> acc
-        Just (c, rest) -> go (acc + charWidth c) rest
+displayWidth = UTF8.foldl (\acc c -> acc + charWidth c) 0
 
--- | Truncate (with a trailing ellipsis) when the input does not fit in 'w'
--- columns; pass it through unchanged otherwise.
-ellipsize :: Int -> ByteString -> ByteString
+-- | These functions truncate with ellipses if needed to get width ≤'w'.
+-- 'forceWidth' adds padding as needed so the width is exactly 'w'.
+ellipsize, forceWidth :: Int -> ByteString -> ByteString
 ellipsize = sizer False
-
--- | Like 'ellipsize', but pads short inputs with trailing spaces to 'w'
--- columns exactly.
-forceWidth :: Int -> ByteString -> ByteString
 forceWidth = sizer True
 
--- The two share an inner walker that finds the largest UTF-8 prefix whose
--- column count is < w, then fills the remaining columns with ellipses.
 sizer :: Bool -> Int -> ByteString -> ByteString
-sizer pad w bs
-    | dw <= w   = if pad then bs <> P.replicate (w - dw) ' ' else bs
-    | otherwise = walk 0 bs
+sizer pad w bs | dw <= w = if pad then bs <> P.replicate (w-dw) ' ' else bs
+               | True    = walk 0 bs
   where
     dw = displayWidth bs
-
-    walk !l rest = case UTF8.uncons rest of
-        -- Unreachable: dw > w means we always hit the truncation branch
-        -- before exhausting the input.  Fall back to the input as a safety
-        -- net so a faulty width invariant never crashes the UI.
-        Nothing -> bs
-        Just (c, rest') ->
-            let l' = l + charWidth c
-            in if l' > w - 1
-                then P.take (P.length bs - P.length rest) bs
-                        <> mconcat (replicate (w - l) ellipsis)
-                else walk l' rest'
+    walk !l rest | l' >= w = P.take (P.length bs - P.length rest) bs
+                                <> mconcat (replicate (w-l) ellipsis)
+                 | True    = walk l' rest'
+      where (c, rest') = fromJust $ UTF8.uncons rest
+            l' = l + charWidth c
 
 ellipsis :: ByteString
 ellipsis = UTF8.fromString "…"
@@ -66,3 +48,4 @@ charWidth = fromIntegral . wcwidth . toEnum . fromEnum
 
 foreign import ccall safe
     wcwidth :: CWchar -> CInt
+

--- a/Width.hs
+++ b/Width.hs
@@ -1,9 +1,8 @@
 -- Copyright (c) 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
--- | Width-aware operations on UTF-8 'ByteString's, using libc 'wcwidth' to
--- determine column widths.  Column counts therefore depend on the runtime
--- locale; expect deterministic results only under a UTF-8 locale.
+-- | Width-aware operations on UTF-8 'ByteString's, using libc 'wcwidth'.
+-- A UTF-8 runtime locale is presumed; counts may differ otherwise.
 module Width (displayWidth, toMaxWidth, toWidth) where
 
 import Base
@@ -25,15 +24,18 @@ toMaxWidth = sizer False
 toWidth = sizer True
 
 sizer :: Bool -> Int -> ByteString -> ByteString
-sizer pad w bs | dw <= w = if pad then bs <> P.replicate (w-dw) ' ' else bs
-               | True    = walk 0 bs
+sizer pad w bs
+    | dw <= w = if pad then bs <> P.replicate (w-dw) ' ' else bs
+    | True    = walk 0 bs
   where
     dw = displayWidth bs
-    walk !l rest | l' >= w = P.take (P.length bs - P.length rest) bs
-                                <> mconcat (replicate (w-l) $ UTF8.fromString "…")
-                 | True    = walk l' rest'
-      where (c, rest') = fromJust $ UTF8.uncons rest -- can't be at end since dw>w
-            l' = l + charWidth c
+    walk !l rest
+        | l' >= w = P.take (P.length bs - P.length rest) bs
+                        <> mconcat (replicate (w-l) $ UTF8.fromString "…")
+        | True    = walk l' rest'
+      where
+        (c, rest') = fromJust $ UTF8.uncons rest -- can't be at end since dw>w
+        l'         = l + charWidth c
 
 charWidth :: Char -> Int
 charWidth = fromIntegral . wcwidth . toEnum . fromEnum

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -54,6 +54,7 @@ library
       Syntax
       Tree
       UI
+      Width
   other-modules:
       Paths_hmp3_ng
   autogen-modules:
@@ -98,6 +99,7 @@ test-suite test
       FastIOSpec
       LexerSpec
       TreeSpec
+      WidthSpec
   build-depends:
     , base
     , bytestring

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -107,4 +107,5 @@ test-suite test
     , hmp3-ng
     , tasty           >=1.4
     , tasty-hunit     >=0.10
+    , utf8-string
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import qualified CoreSpec
 import qualified FastIOSpec
 import qualified LexerSpec
 import qualified TreeSpec
+import qualified WidthSpec
 
 main :: IO ()
 main = defaultMain $ testGroup "hmp3-ng"
@@ -13,4 +14,5 @@ main = defaultMain $ testGroup "hmp3-ng"
     , FastIOSpec.tests
     , LexerSpec.tests
     , TreeSpec.tests
+    , WidthSpec.tests
     ]

--- a/test/WidthSpec.hs
+++ b/test/WidthSpec.hs
@@ -6,7 +6,7 @@ import Test.Tasty.HUnit
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.UTF8 as UTF8
 
-import Width (displayWidth, ellipsize, forceWidth)
+import Width (displayWidth, toMaxWidth, toWidth)
 
 -- These tests depend on wcwidth's behaviour under a UTF-8 locale and on a
 -- handful of codepoints whose canonical widths are well-known:
@@ -22,42 +22,42 @@ tests = testGroup "Width"
         [ testCase "empty"             $ displayWidth ""                  @?= 0
         , testCase "ascii"             $ displayWidth "hello"             @?= 5
         , testCase "latin-extended"    $ displayWidth (utf8 "café")       @?= 4
-        , testCase "cjk doubles each"  $ displayWidth (utf8 "中文")        @?= 4
-        , testCase "mixed"             $ displayWidth (utf8 "中a文b")      @?= 6
+        , testCase "cjk doubles each"  $ displayWidth (utf8 "中文")       @?= 4
+        , testCase "mixed"             $ displayWidth (utf8 "中a文b")     @?= 6
         ]
-    , testGroup "ellipsize"
+    , testGroup "toMaxWidth"
         [ testCase "wider than input passes through"
-            $ ellipsize 10 "hello"        @?= "hello"
+            $ toMaxWidth 10 "hello"        @?= "hello"
         , testCase "exactly the width passes through"
-            $ ellipsize 5 "hello"         @?= "hello"
+            $ toMaxWidth 5 "hello"         @?= "hello"
         , testCase "truncate ascii with ellipsis"
-            $ ellipsize 4 "hello"         @?= "hel" <> utf8 "…"
+            $ toMaxWidth 4 "hello"         @?= "hel" <> utf8 "…"
         , testCase "narrower truncate"
-            $ ellipsize 2 "hello"         @?= "h"   <> utf8 "…"
+            $ toMaxWidth 2 "hello"         @?= "h"   <> utf8 "…"
         , testCase "width one becomes a lone ellipsis"
-            $ ellipsize 1 "hello"         @?= utf8 "…"
+            $ toMaxWidth 1 "hello"         @?= utf8 "…"
         , testCase "width zero becomes empty"
-            $ ellipsize 0 "hello"         @?= ""
+            $ toMaxWidth 0 "hello"         @?= ""
         , testCase "wide char truncation respects boundaries"
-            -- "中文hi" is 6 columns (2+2+1+1); ellipsize 4 keeps the first
+            -- "中文hi" is 6 columns (2+2+1+1); toMaxWidth 4 keeps the first
             -- wide char plus two ellipses to fill the remaining columns.
-            $ ellipsize 4 (utf8 "中文hi")  @?= utf8 "中……"
+            $ toMaxWidth 4 (utf8 "中文hi") @?= utf8 "中……"
         , testCase "wide char gives way to single ellipsis at the boundary"
-            -- "中文" is 4 columns; ellipsize 3 keeps the first wide char
+            -- "中文" is 4 columns; toMaxWidth 3 keeps the first wide char
             -- (2 columns) plus one ellipsis (1 column).
-            $ ellipsize 3 (utf8 "中文")    @?= utf8 "中…"
+            $ toMaxWidth 3 (utf8 "中文")   @?= utf8 "中…"
         ]
-    , testGroup "forceWidth"
+    , testGroup "toWidth"
         [ testCase "pads short ascii"
-            $ forceWidth 10 "hello"       @?= "hello     "
+            $ toWidth 10 "hello"       @?= "hello     "
         , testCase "pad with empty input"
-            $ forceWidth 4 ""             @?= "    "
+            $ toWidth 4 ""             @?= "    "
         , testCase "exact width unchanged"
-            $ forceWidth 5 "hello"        @?= "hello"
-        , testCase "truncate matches ellipsize when over-width"
-            $ forceWidth 4 "hello"        @?= "hel" <> utf8 "…"
+            $ toWidth 5 "hello"        @?= "hello"
+        , testCase "truncate matches toMaxWidth when over-width"
+            $ toWidth 4 "hello"        @?= "hel" <> utf8 "…"
         , testCase "pads after a wide-char content too"
-            $ forceWidth 5 (utf8 "中a")   @?= utf8 "中a" <> "  "
+            $ toWidth 5 (utf8 "中a")   @?= utf8 "中a" <> "  "
         ]
     ]
 

--- a/test/WidthSpec.hs
+++ b/test/WidthSpec.hs
@@ -1,0 +1,65 @@
+module WidthSpec (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.UTF8 as UTF8
+
+import Width (displayWidth, ellipsize, forceWidth)
+
+-- These tests depend on wcwidth's behaviour under a UTF-8 locale and on a
+-- handful of codepoints whose canonical widths are well-known:
+--   * ASCII chars are 1 column.
+--   * Latin-Extended chars (é, ñ) are 1 column.
+--   * Common CJK chars (中) are 2 columns.
+--   * The horizontal ellipsis (…) is 1 column.
+-- They are not deterministic under the C locale.
+
+tests :: TestTree
+tests = testGroup "Width"
+    [ testGroup "displayWidth"
+        [ testCase "empty"             $ displayWidth ""                  @?= 0
+        , testCase "ascii"             $ displayWidth "hello"             @?= 5
+        , testCase "latin-extended"    $ displayWidth (utf8 "café")       @?= 4
+        , testCase "cjk doubles each"  $ displayWidth (utf8 "中文")        @?= 4
+        , testCase "mixed"             $ displayWidth (utf8 "中a文b")      @?= 6
+        ]
+    , testGroup "ellipsize"
+        [ testCase "wider than input passes through"
+            $ ellipsize 10 "hello"        @?= "hello"
+        , testCase "exactly the width passes through"
+            $ ellipsize 5 "hello"         @?= "hello"
+        , testCase "truncate ascii with ellipsis"
+            $ ellipsize 4 "hello"         @?= "hel" <> utf8 "…"
+        , testCase "narrower truncate"
+            $ ellipsize 2 "hello"         @?= "h"   <> utf8 "…"
+        , testCase "width one becomes a lone ellipsis"
+            $ ellipsize 1 "hello"         @?= utf8 "…"
+        , testCase "width zero becomes empty"
+            $ ellipsize 0 "hello"         @?= ""
+        , testCase "wide char truncation respects boundaries"
+            -- "中文hi" is 6 columns (2+2+1+1); ellipsize 4 keeps the first
+            -- wide char plus two ellipses to fill the remaining columns.
+            $ ellipsize 4 (utf8 "中文hi")  @?= utf8 "中……"
+        , testCase "wide char gives way to single ellipsis at the boundary"
+            -- "中文" is 4 columns; ellipsize 3 keeps the first wide char
+            -- (2 columns) plus one ellipsis (1 column).
+            $ ellipsize 3 (utf8 "中文")    @?= utf8 "中…"
+        ]
+    , testGroup "forceWidth"
+        [ testCase "pads short ascii"
+            $ forceWidth 10 "hello"       @?= "hello     "
+        , testCase "pad with empty input"
+            $ forceWidth 4 ""             @?= "    "
+        , testCase "exact width unchanged"
+            $ forceWidth 5 "hello"        @?= "hello"
+        , testCase "truncate matches ellipsize when over-width"
+            $ forceWidth 4 "hello"        @?= "hel" <> utf8 "…"
+        , testCase "pads after a wide-char content too"
+            $ forceWidth 5 (utf8 "中a")   @?= utf8 "中a" <> "  "
+        ]
+    ]
+
+utf8 :: String -> ByteString
+utf8 = UTF8.fromString

--- a/test/WidthSpec.hs
+++ b/test/WidthSpec.hs
@@ -19,33 +19,33 @@ import Width (displayWidth, toMaxWidth, toWidth)
 tests :: TestTree
 tests = testGroup "Width"
     [ testGroup "displayWidth"
-        [ testCase "empty"             $ displayWidth ""                  @?= 0
-        , testCase "ascii"             $ displayWidth "hello"             @?= 5
-        , testCase "latin-extended"    $ displayWidth (utf8 "café")       @?= 4
-        , testCase "cjk doubles each"  $ displayWidth (utf8 "中文")       @?= 4
-        , testCase "mixed"             $ displayWidth (utf8 "中a文b")     @?= 6
+        [ testCase "empty"             $ displayWidth ""              @?= 0
+        , testCase "ascii"             $ displayWidth "hello"         @?= 5
+        , testCase "latin-extended"    $ displayWidth (u"café")       @?= 4
+        , testCase "cjk doubles each"  $ displayWidth (u"中文")       @?= 4
+        , testCase "mixed"             $ displayWidth (u"中a文b")     @?= 6
         ]
     , testGroup "toMaxWidth"
         [ testCase "wider than input passes through"
-            $ toMaxWidth 10 "hello"        @?= "hello"
+            $ toMaxWidth 10 "hello"    @?= "hello"
         , testCase "exactly the width passes through"
-            $ toMaxWidth 5 "hello"         @?= "hello"
+            $ toMaxWidth 5 "hello"     @?= "hello"
         , testCase "truncate ascii with ellipsis"
-            $ toMaxWidth 4 "hello"         @?= "hel" <> utf8 "…"
+            $ toMaxWidth 4 "hello"     @?= "hel" <> u"…"
         , testCase "narrower truncate"
-            $ toMaxWidth 2 "hello"         @?= "h"   <> utf8 "…"
+            $ toMaxWidth 2 "hello"     @?= "h"   <> u"…"
         , testCase "width one becomes a lone ellipsis"
-            $ toMaxWidth 1 "hello"         @?= utf8 "…"
+            $ toMaxWidth 1 "hello"     @?= u"…"
         , testCase "width zero becomes empty"
-            $ toMaxWidth 0 "hello"         @?= ""
+            $ toMaxWidth 0 "hello"     @?= ""
         , testCase "wide char truncation respects boundaries"
             -- "中文hi" is 6 columns (2+2+1+1); toMaxWidth 4 keeps the first
             -- wide char plus two ellipses to fill the remaining columns.
-            $ toMaxWidth 4 (utf8 "中文hi") @?= utf8 "中……"
+            $ toMaxWidth 4 (u"中文hi") @?= u"中……"
         , testCase "wide char gives way to single ellipsis at the boundary"
             -- "中文" is 4 columns; toMaxWidth 3 keeps the first wide char
             -- (2 columns) plus one ellipsis (1 column).
-            $ toMaxWidth 3 (utf8 "中文")   @?= utf8 "中…"
+            $ toMaxWidth 3 (u"中文")   @?= u"中…"
         ]
     , testGroup "toWidth"
         [ testCase "pads short ascii"
@@ -55,11 +55,11 @@ tests = testGroup "Width"
         , testCase "exact width unchanged"
             $ toWidth 5 "hello"        @?= "hello"
         , testCase "truncate matches toMaxWidth when over-width"
-            $ toWidth 4 "hello"        @?= "hel" <> utf8 "…"
+            $ toWidth 4 "hello"        @?= "hel" <> u"…"
         , testCase "pads after a wide-char content too"
-            $ toWidth 5 (utf8 "中a")   @?= utf8 "中a" <> "  "
+            $ toWidth 5 (u "中a")      @?= u"中a" <> "  "
         ]
     ]
 
-utf8 :: String -> ByteString
-utf8 = UTF8.fromString
+u :: String -> ByteString
+u = UTF8.fromString


### PR DESCRIPTION
The display path used to carry two representations: a 'B ByteString' constructor for already-encoded UTF-8 bytes, and a 'U String' constructor for Haskell-side text that needed width-aware truncation through 'wcwidth' on Chars.  Drawing then dispatched: 'waddnstr' for the B side, 'Curses.wAddStr' for the U side.

This commit unifies on UTF-8 ByteString:

  * 'StringA' carries '[(ByteString, Style)]' instead of '[(AmbiString, Style)]'; the 'AmbiString' type is gone.
  * 'displayWidth', 'sizer', 'ellipsize', 'forceWidth' operate on UTF-8 ByteString directly, walking codepoints via 'Data.ByteString.UTF8.uncons'/'foldr' and summing 'wcwidth'.
  * Every 'UTF8.toString'/'UTF8.fromString' round-trip on the display path is gone; modal-text construction stays in ByteString throughout.
  * 'Curses.wAddStr' is no longer called; everything goes via 'waddnstr'.  'drawAmbiString' becomes 'drawSegment'.
  * 'histVisible' in HState is now 'Maybe [(ByteString, (Int, ByteString))]'; 'Core.showHist' no longer decodes through String.

The non-ASCII byte literals ('↑', '↓', '←', '→', '…') stay encoded explicitly via 'UTF8.fromString' — ByteString's 'IsString' instance is 'Data.ByteString.Char8.pack', which truncates each Char to a byte and would produce mojibake for these.