### PR TITLE
Rework mpg123 concurrency.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -52,3 +52,6 @@ sequenceWhile _ [] = pure []
 sequenceWhile p (m:ms) = m >>= \a ->
     if p a then (a:) <$> sequenceWhile p ms else pure []
 
+whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
+whenJust mb f = maybe (pure ()) f mb
+

--- a/Base.hs
+++ b/Base.hs
@@ -52,6 +52,3 @@ sequenceWhile _ [] = pure []
 sequenceWhile p (m:ms) = m >>= \a ->
     if p a then (a:) <$> sequenceWhile p ms else pure []
 
-whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
-whenJust mb f = maybe (pure ()) f mb
-

--- a/Core.hs
+++ b/Core.hs
@@ -11,7 +11,7 @@ module Core (
     start,
     shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
-    forcePause, quit, putmsg, clrmsg, toggleHelp, play, playCur,
+    forcePause, putmsg, clrmsg, toggleHelp, play, playCur,
     jumpToPlaying, jump, jumpRel,
     upPage, downPage,
     seekStart,
@@ -137,7 +137,7 @@ mpgLoop :: IO ()
 mpgLoop = runForever do
     mmpg <- findExecutable mp3Tool
     case mmpg of
-      Nothing     -> quit (Just $ "Cannot find " ++ mp3Tool ++ " in path")
+      Nothing     -> shutdown (Just $ "Cannot find " ++ mp3Tool ++ " in path")
       Just mppath -> do
         mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
         case mv of
@@ -425,10 +425,6 @@ forcePause :: IO ()
 forcePause = do
     st <- getsHS status
     when (st == Playing) pause
-
--- | Shutdown and exit
-quit :: Maybe String -> IO ()
-quit = shutdown
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -8,22 +8,22 @@
 -- | Main module. 
 --
 module Core (
-        start,
-        shutdown,
-        seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
-        forcePause, quit, putmsg, clrmsg, toggleHelp, play, playCur,
-        jumpToPlaying, jump, jumpRel,
-        upPage, downPage,
-        seekStart,
-        blacklist,
-        showHist, hideHist,
-        jumpToMatchDir, jumpToMatchFile,
-        toggleFocus, jumpToNextDir, jumpToPrevDir,
-        loadConfig,
-        discardErrors,
-        toggleExit,
-        showTimeDiff_,
-    ) where
+    start,
+    shutdown,
+    seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
+    forcePause, quit, putmsg, clrmsg, toggleHelp, play, playCur,
+    jumpToPlaying, jump, jumpRel,
+    upPage, downPage,
+    seekStart,
+    blacklist,
+    showHist, hideHist,
+    jumpToMatchDir, jumpToMatchFile,
+    toggleFocus, jumpToNextDir, jumpToPrevDir,
+    loadConfig,
+    discardErrors,
+    toggleExit,
+    showTimeDiff_,
+) where
 
 import Base
 
@@ -35,6 +35,7 @@ import FastIO               (send, FiltHandle(..), newFiltHandle)
 import Tree hiding (File, Dir)
 import qualified Tree (File,Dir)
 import qualified UI
+import Config (defaultStyle)
 
 import Text.Regex.PCRE.Light
 import {-# SOURCE #-} Keymap (keyLoop)
@@ -67,21 +68,20 @@ mp3Tool =
 start :: Bool -> Tree -> IO ()
 start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
-    t0 <- forkIO mpgLoop    -- start this off early, to give mpg123 time to settle
-
     c <- UI.start -- initialise curses
 
     now <- getMonoTime
     mode <- readState
 
-    -- fork some threads
-    t1 <- forkIO $ mpgInput readf
-    t2 <- forkIO refreshLoop
-    t3 <- forkIO clockLoop
-    t4 <- forkIO uptimeLoop
-    t5 <- forkIO
+    threads <- sequence $ map forkIO
+        [ mpgLoop
+        , mpgInput readf
+        , refreshLoop
+        , clockLoop
+        , uptimeLoop
         -- mpg321 uses stderr for @F messages
-        $ if mp3Tool == "mpg321" then mpgInput errh else errorLoop
+        , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
+        ]
 
     silentlyModifyST $ \s -> s
         { music        = fs
@@ -93,12 +93,11 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
         , uptime       = showTimeDiff now now
         , boottime     = now
         , config       = c
-        , threads      = [t0,t1,t2,t3,t4,t5] }
+        , threads      }
 
     loadConfig
 
-    when (0 <= (snd . bounds $ fs)) do
-        if mode == Random then modifySTM jumpToRandom else playCur
+    if mode == Random then modifySTM jumpToRandom else playCur
     when (not playNow) pause
 
     run         -- won't restart if this fails!
@@ -112,11 +111,7 @@ runForever fn = catch (forever fn) handler
         handler :: SomeException -> IO ()
         handler e =
             unless (exitTime e) $
-                (warnA . show) e >> runForever fn        -- reopen the catch
-
--- | Standard combinator.
-whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
-whenJust mb f = maybe (pure ()) f mb
+                (warnA . ("outer: " ++) . show) e >> runForever fn  -- reopen the catch
 
 -- | Generic handler
 -- I don't know why these are ignored, but preserving old logic.
@@ -138,7 +133,7 @@ exitTime e | is @IOException e = False -- ignore
 -- For example, if we can't start it two times in a row, perhaps give up?
 --
 mpgLoop :: IO ()
-mpgLoop = runForever do
+mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
     mmpg <- findExecutable mp3Tool
     case mmpg of
       Nothing     -> quit (Just $ "Cannot find " ++ mp3Tool ++ " in path")
@@ -146,21 +141,25 @@ mpgLoop = runForever do
 
         -- if we're never able to start mpg123, do something sensible
         mv <- catch (pure <$> runInteractiveProcess mppath ["-R", "-"] Nothing Nothing)
-                    (\ (e :: SomeException) ->
-                           do warnA ("Unable to start " ++ mp3Tool ++ ": " ++ show e)
+                    (\ (ex :: SomeException) ->
+                           do warnA ("Unable to start " ++ mp3Tool ++ ": " ++ show ex)
                               pure Nothing)
 
         whenJust mv \ (hw, r, e, pid) -> do
+            spawns <- readIORef spawnsRef
 
-            mhw         <- newMVar hw
-            mew         <- newMVar =<< newFiltHandle e
-            mfilep      <- newMVar =<< newFiltHandle r
+            when (spawns > 1) do
+                void $ takeMVar =<< getsST readf
+                void $ takeMVar =<< getsST writeh
+                void $ takeMVar =<< getsST errh
+                warnA $ "Started " ++ mp3Tool ++ " #" ++ show spawns
+
+            join $ putMVar <$> getsST readf <*> newFiltHandle r
+            join $ putMVar <$> getsST errh <*> newFiltHandle e
+            flip putMVar hw =<< getsST writeh
 
             modifyST $ \st ->
                st { mp3pid    = Just pid
-                  , writeh    = mhw
-                  , errh      = mew
-                  , readf     = mfilep
                   , status    = Stopped
                   , info      = Nothing
                   , id3       = Nothing
@@ -169,7 +168,8 @@ mpgLoop = runForever do
             catch @SomeException (void $ waitForProcess pid) (\_ -> pure ())
             stop <- getsST doNotResuscitate
             when stop exitSuccess
-            warnA $ "Restarting " ++ mppath ++ " ..."
+            warnA $ "Restarting " ++ mppath ++ " (#" ++ show spawns ++ ")..."
+            modifyIORef' spawnsRef (+ 1)
 
         -- Delay to slow spawn loops in case of trouble.
         threadDelay 4_000_000
@@ -228,7 +228,7 @@ clockLoop = runForever $ threadDelay delay >> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    getsST errh >>= readMVar >>= hGetLine . filtHandle >>= warnA
+    getsST errh >>= readMVar >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
 
 ------------------------------------------------------------------------
 
@@ -243,7 +243,7 @@ mpgInput field = runForever $ do
     res  <- parser fp
     case res of
         Right m       -> handleMsg m
-        Left (Just e) -> (warnA.show) e
+        Left (Just e) -> (warnA . ("read: "++) . show) e
         _             -> pure ()
 
 ------------------------------------------------------------------------
@@ -265,8 +265,7 @@ shutdown ms =
                 Just pid -> do
                     h <- readMVar (writeh st)
                     send h Quit                        -- ask politely
-                    waitForProcess pid
-                    pure ()
+                    void $ waitForProcess pid
 
     `finally`
 
@@ -565,7 +564,7 @@ readState = do
     modeM <- if b
         then readMaybe <$!> readFile f
         else pure Nothing
-    pure $ fromMaybe (mode emptySt) modeM
+    pure $ fromMaybe minBound modeM
 
 ------------------------------------------------------------------------
 -- Read styles from style.conf
@@ -594,14 +593,14 @@ loadConfig = do
                 initcolours sty
                 modifyST $ \st -> st { config = sty }
       else do
-        let sty = config emptySt
-        initcolours sty
-        modifyST $ \st -> st { config = sty }
+        initcolours defaultStyle
+        modifyST $ \st -> st { config = defaultStyle }
     UI.resetui
 
 ------------------------------------------------------------------------
 -- Editing the minibuffer
 
+-- TODO maybe shouldn't be silent?
 putmsg :: StringA -> IO ()
 putmsg s = silentlyModifyST $ \st -> st { minibuffer = s }
 
@@ -611,7 +610,10 @@ clrmsg = putmsg (Fast P.empty defaultSty)
 
 --
 warnA :: String -> IO ()
-warnA x = do
-    sty <- getsST config
-    putmsg $ Fast (P.pack x) (warnings sty)
+warnA x =
+    -- Handle read errors get a respawn, already reported.
+    unless ("hGetLine" `isInfixOf` x) do
+        sty <- getsST config
+        putmsg $ Fast (P.pack x) (warnings sty)
+        touchST
 

--- a/Core.hs
+++ b/Core.hs
@@ -137,7 +137,7 @@ mpgLoop :: IO ()
 mpgLoop = runForever do
     mmpg <- findExecutable mp3Tool
     case mmpg of
-      Nothing     -> shutdown (Just $ "Cannot find " ++ mp3Tool ++ " in path")
+      Nothing     -> shutdown $ Just $ "Cannot find " ++ mp3Tool ++ " in path"
       Just mppath -> do
         mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
         case mv of
@@ -145,7 +145,6 @@ mpgLoop = runForever do
             warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
           Right (writeh, r, e, pid) -> do
-
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { mpgPid    = Just pid
                 , status    = Stopped
@@ -191,7 +190,7 @@ uptimeLoop = runForever $ do
     now <- getMonoTime
     modifyHS_ $ \st -> st { uptime = showTimeDiff (boottime st) now }
   where
-    delay = 5 * 1000 * 1000 -- refresh every 5 seconds
+    delay = 5_000_000
 
 ------------------------------------------------------------------------
 
@@ -215,11 +214,11 @@ showTimeDiff = showTimeDiff_ False
 
 ------------------------------------------------------------------------
 
--- | Once each half second, wake up and redraw the clock
+-- | Periodically wake up and redraw the clock
 clockLoop :: IO ()
 clockLoop = runForever $ threadDelay delay >> UI.refreshClock
   where
-    delay = 500 * 1000 -- 0.5 second
+    delay = 200_000
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -43,6 +43,7 @@ import {-# SOURCE #-} Keymap (keyLoop)
 import qualified Data.ByteString.Char8 as P
 import qualified Data.Sequence as Seq
 
+import Control.Arrow            ((&&&))
 import Data.Array               ((!), bounds, Array)
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
                                  getXdgDirectory, XdgDirectory(..))
@@ -97,7 +98,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     loadConfig
 
-    if mode == Random then modifyHSM jumpToRandom else playCur
+    if mode == Random then jumpToRandom else playCur
     when (not playNow) pause
 
     run         -- won't restart if this fails!
@@ -256,7 +257,7 @@ shutdown ms = do
     silentlyModifyHS $ \st -> st { doNotResuscitate = True }
     discardErrors writeState
     mpid <- getsHS mpgPid
-    whenJust mpid \pid -> do
+    flip (maybe $ pure ()) mpid \pid -> do
         sendMpg Quit               -- ask politely
         void $ waitForProcess pid
 
@@ -350,13 +351,14 @@ jumpRel r | r < 0 || r >= 1 = pure ()
 
 -- | Load and play the song under the cursor
 play :: IO ()
-play = modifyHSM $ \st ->
-    if current st == cursor st
-    then jumpToRandom st
-    else playAtN st (const $ cursor st)
+play = do
+    (curr, curs) <- getsHS (current &&& cursor)
+    if curr == curs
+        then jumpToRandom
+        else playAtN (const curs)
 
 playCur :: IO ()
-playCur = modifyHSM $ \st -> playAtN st (const $ cursor st)
+playCur = playAtN . const =<< getsHS cursor
 
 blacklist :: IO ()
 blacklist = do
@@ -366,53 +368,52 @@ blacklist = do
         in P.intercalate (P.singleton '/') [dname $ folders st ! fdir fe, fbase fe]
 
 -- | Jump to a random song
-jumpToRandom :: HState -> IO HState
-jumpToRandom st = playAtN st . const =<< randomRIO (0, size st - 1)
+jumpToRandom :: IO ()
+jumpToRandom = playAtN . const =<< (\sz -> randomRIO (0, sz-1)) =<< getsHS size
 
 -- | Play the song before the current song, if we're not at the beginning
 -- If we're at the beginning, and loop mode is on, then loop to the end
 -- If we're in random mode, play the next random track
 playPrev :: IO ()
-playPrev = modifyHSM \st -> case mode st of
-    Random -> jumpToRandom st
-    Single -> pure st
-    _ | current st > 0
-           -> playAtN st (subtract 1)
-    Loop   -> playAtN st (const (size st - 1))
-    Once   -> pure st
+playPrev = do
+    (mo, (sz, cur)) <- getsHS (mode &&& size &&& current)
+    case mo of
+        Random      -> jumpToRandom
+        Single      -> pure ()
+        _ | cur > 0 -> playAtN (subtract 1)
+        Loop        -> playAtN (const (sz-1))
+        Once        -> pure ()
 
 -- | Play the song following the current song, if we're not at the end
 -- If we're at the end, and loop mode is on, then loop to the start
 -- If we're in random mode, play the next random track
 playNext :: IO ()
-playNext = modifyHSM \st -> case mode st of
-    Random -> jumpToRandom st
-    Single -> pure st
-    _ | current st < size st - 1
-           -> playAtN st (+ 1)
-    Loop   -> playAtN st (const 0)
-    Once   -> pure st
+playNext = do
+    (mo, notLast) <- getsHS (mode &&& (\st -> current st < size st - 1))
+    case mo of
+        Random      -> jumpToRandom
+        Single      -> pure ()
+        _ | notLast -> playAtN (+ 1)
+        Loop        -> playAtN (const 0)
+        Once        -> pure ()
 
 -- | Generic next song selection
 -- If the cursor and current are currently the same, continue that.
-playAtN :: HState -> (Int -> Int) -> IO HState
-playAtN st fn = do
+playAtN :: (Int -> Int) -> IO ()
+playAtN fn = do
     now <- getMonoTime
-    let m   = music st
-        i   = current st
-        new = fn i
-        fe  = m ! new
-        -- unsure of this GBH (2008)
-        f   = P.intercalate (P.singleton '/')
-                 [dname $ folders st ! fdir fe, fbase fe]
-        j   = cursor  st
-        st' = st { current = new
-                 , status  = Playing
-                 , cursor  = if i == cursor st then new else j
-                 , playHist = Seq.take 36 $ (now, new) Seq.<| playHist st
-                 }
-    sendMpg $ Load f
-    pure st'
+    file <- modifyHS \st@HState{..} ->
+        let new = fn current
+            fe  = music ! new
+            f   = P.intercalate (P.singleton '/')
+                     [dname $ folders ! fdir fe, fbase fe]
+            st' = st { current = new
+                     , status  = Playing
+                     , cursor  = if current == cursor then new else cursor
+                     , playHist = Seq.take 36 $ (now, new) Seq.<| playHist
+                     }
+        in (st', f)
+    sendMpg $ Load file
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -138,14 +138,12 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
     case mmpg of
       Nothing     -> quit (Just $ "Cannot find " ++ mp3Tool ++ " in path")
       Just mppath -> do
+        mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
+        case mv of
+          Left (ex :: SomeException) ->
+            warnA $ "Unable to start " ++ mp3Tool ++ ": " ++ show ex ++ "; retrying..."
 
-        -- if we're never able to start mpg123, do something sensible
-        mv <- catch (pure <$> runInteractiveProcess mppath ["-R", "-"] Nothing Nothing)
-                    (\ (ex :: SomeException) ->
-                           do warnA ("Unable to start " ++ mp3Tool ++ ": " ++ show ex)
-                              pure Nothing)
-
-        whenJust mv \ (mpgWriteh, r, e, pid) -> do
+          Right (mpgWriteh, r, e, pid) -> do
             spawns <- readIORef spawnsRef
 
             when (spawns > 1) do
@@ -171,7 +169,7 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
             modifyIORef' spawnsRef (+ 1)
 
         -- Delay to slow spawn loops in case of trouble.
-        threadDelay 400_000
+        threadDelay 4_000_000
 
 
 ------------------------------------------------------------------------

--- a/Core.hs
+++ b/Core.hs
@@ -31,7 +31,7 @@ import Syntax
 import Lexer                (parser)
 import State
 import Style
-import FastIO               (send, FiltHandle(..), newFiltHandle)
+import FastIO               (FiltHandle(..), newFiltHandle)
 import Tree hiding (File, Dir)
 import qualified Tree (File,Dir)
 import qualified UI
@@ -75,12 +75,12 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     threads <- sequence $ map forkIO
         [ mpgLoop
-        , mpgInput readf
+        , mpgInput mpgReadf
         , refreshLoop
         , clockLoop
         , uptimeLoop
         -- mpg321 uses stderr for @F messages
-        , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
+        , if mp3Tool == "mpg321" then mpgInput mpgErrh else errorLoop
         ]
 
     silentlyModifyST $ \s -> s
@@ -145,34 +145,33 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
                            do warnA ("Unable to start " ++ mp3Tool ++ ": " ++ show ex)
                               pure Nothing)
 
-        whenJust mv \ (hw, r, e, pid) -> do
+        whenJust mv \ (mpgWriteh, r, e, pid) -> do
             spawns <- readIORef spawnsRef
 
             when (spawns > 1) do
-                void $ takeMVar =<< getsST readf
-                void $ takeMVar =<< getsST writeh
-                void $ takeMVar =<< getsST errh
+                void $ takeMVar mpg
                 warnA $ "Started " ++ mp3Tool ++ " #" ++ show spawns
 
-            join $ putMVar <$> getsST readf <*> newFiltHandle r
-            join $ putMVar <$> getsST errh <*> newFiltHandle e
-            flip putMVar hw =<< getsST writeh
+            modifyST $ \st -> st
+                { mpgPid    = Just pid
+                , status    = Stopped
+                , info      = Nothing
+                , id3       = Nothing
+                }
 
-            modifyST $ \st ->
-               st { mp3pid    = Just pid
-                  , status    = Stopped
-                  , info      = Nothing
-                  , id3       = Nothing
-                  }
+            mpgReadf <- newFiltHandle r
+            mpgErrh <- newFiltHandle e
+            putMVar mpg Mpg { mpgReadf, mpgErrh, mpgWriteh }
 
-            catch @SomeException (void $ waitForProcess pid) (\_ -> pure ())
+            catch @SomeException (void $ waitForProcess pid) (const $ pure ())
+            silentlyModifyST $ \st -> st { mpgPid = Nothing }
             stop <- getsST doNotResuscitate
             when stop exitSuccess
             warnA $ "Restarting " ++ mppath ++ " (#" ++ show spawns ++ ")..."
             modifyIORef' spawnsRef (+ 1)
 
         -- Delay to slow spawn loops in case of trouble.
-        threadDelay 4_000_000
+        threadDelay 400_000
 
 
 ------------------------------------------------------------------------
@@ -228,7 +227,7 @@ clockLoop = runForever $ threadDelay delay >> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    getsST errh >>= readMVar >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
+    mpgErrh <$> readMVar mpg >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
 
 ------------------------------------------------------------------------
 
@@ -236,10 +235,9 @@ errorLoop = runForever $
 -- shutdown kills the other end of the pipe, hGetLine will fail, so we
 -- take that chance to exit.
 --
-mpgInput :: (HState -> MVar FiltHandle) -> IO ()
+mpgInput :: (Mpg -> FiltHandle) -> IO ()
 mpgInput field = runForever $ do
-    mvar <- getsST field
-    fp   <- readMVar mvar
+    fp   <- field <$> readMVar mpg
     res  <- parser fp
     case res of
         Right m       -> handleMsg m
@@ -256,16 +254,13 @@ run = runForever keyLoop
 
 -- | Close most things. Important to do all the jobs:
 shutdown :: Maybe String -> IO ()
-shutdown ms =
-    do  silentlyModifyST $ \st -> st { doNotResuscitate = True }
-        discardErrors writeState
-        withST $ \st -> do
-            case mp3pid st of
-                Nothing  -> pure ()
-                Just pid -> do
-                    h <- readMVar (writeh st)
-                    send h Quit                        -- ask politely
-                    void $ waitForProcess pid
+shutdown ms = do
+    silentlyModifyST $ \st -> st { doNotResuscitate = True }
+    discardErrors writeState
+    mpid <- getsST mpgPid
+    whenJust mpid \pid -> do
+        sendMpg Quit               -- ask politely
+        void $ waitForProcess pid
 
     `finally`
 
@@ -317,10 +312,8 @@ seek fn = do
     case f of
         Nothing -> pure ()
         Just g  -> do
-            withST $ \st -> do
-                h <- readMVar (writeh st)
-                send h $ Jump (fn g)
-                forceNextPacket         -- don't drop the next Frame.
+            sendMpg $ Jump (fn g)
+            forceNextPacket         -- don't drop the next Frame.
             silentlyModifyST $ \st -> st { clockUpdate = True }
 
 
@@ -369,10 +362,10 @@ playCur = modifySTM $ \st -> playAtN st (const $ cursor st)
 
 blacklist :: IO ()
 blacklist = do
-  st <- getsST id
-  appendFile ".hmp3-delete" . (++"\n") . P.unpack $
-    let fe = music st ! cursor st
-    in P.intercalate (P.singleton '/') [dname $ folders st ! fdir fe, fbase fe]
+    st <- getsST id
+    appendFile ".hmp3-delete" . (++"\n") . P.unpack $
+        let fe = music st ! cursor st
+        in P.intercalate (P.singleton '/') [dname $ folders st ! fdir fe, fbase fe]
 
 -- | Jump to a random song
 jumpToRandom :: HState -> IO HState
@@ -420,15 +413,14 @@ playAtN st fn = do
                  , cursor  = if i == cursor st then new else j
                  , playHist = Seq.take 36 $ (now, new) Seq.<| playHist st
                  }
-    h <- readMVar (writeh st)
-    send h (Load f)
+    sendMpg $ Load f
     pure st'
 
 ------------------------------------------------------------------------
 
 -- | Toggle pause on the current song
 pause :: IO ()
-pause = withST $ \st -> readMVar (writeh st) >>= flip send Pause
+pause = sendMpg Pause
 
 -- | Always pause
 forcePause :: IO ()

--- a/Core.hs
+++ b/Core.hs
@@ -134,7 +134,7 @@ exitTime e | is @IOException e = False -- ignore
 -- For example, if we can't start it two times in a row, perhaps give up?
 --
 mpgLoop :: IO ()
-mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
+mpgLoop = runForever do
     mmpg <- findExecutable mp3Tool
     case mmpg of
       Nothing     -> quit (Just $ "Cannot find " ++ mp3Tool ++ " in path")
@@ -142,14 +142,9 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
         mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
         case mv of
           Left (ex :: SomeException) ->
-            warnA $ "Unable to start " ++ mp3Tool ++ ": " ++ show ex ++ "; retrying..."
+            warnA $ "Unable to start " ++ mppath ++ ": " ++ show ex ++ "; retrying..."
 
           Right (writeh, r, e, pid) -> do
-            spawns <- readIORef spawnsRef
-
-            when (spawns > 1) do
-                void $ takeMVar mpg
-                warnA $ "Started " ++ mp3Tool ++ " #" ++ show spawns
 
             modifyHS_ $ \st -> st
                 { mpgPid    = Just pid
@@ -163,14 +158,18 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
             putMVar mpg Mpg { readf, errh, writeh }
 
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
+
             silentlyModifyHS $ \st -> st { mpgPid = Nothing }
+            void $ takeMVar mpg
+
             stop <- getsHS doNotResuscitate
             when stop exitSuccess
-            warnA $ "Restarting " ++ mppath ++ " (#" ++ show spawns ++ ")..."
-            modifyIORef' spawnsRef (+ 1)
+            threadDelay 1_000_000  -- let threads spit errors
+            warnA $ "Restarting " ++ mppath ++ "..."
 
-        -- Delay to slow spawn loops in case of trouble.
+        -- Slow spawn loops in case of trouble.
         threadDelay 4_000_000
+        warnA "Ready" -- optimistic but will get overwritten on error
 
 
 ------------------------------------------------------------------------
@@ -226,7 +225,7 @@ clockLoop = runForever $ threadDelay delay >> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    errh <$> readMVar mpg >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
+    readMVar mpg <&> errh >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
 
 ------------------------------------------------------------------------
 
@@ -236,8 +235,7 @@ errorLoop = runForever $
 --
 mpgInput :: (Mpg -> FiltHandle) -> IO ()
 mpgInput field = runForever $ do
-    fp   <- field <$> readMVar mpg
-    res  <- parser fp
+    res <- parser =<< field <$> readMVar mpg
     case res of
         Right m       -> handleMsg m
         Left (Just e) -> (warnA . ("read: "++) . show) e
@@ -601,10 +599,8 @@ clrmsg = putmsg (Fast P.empty defaultSty)
 
 --
 warnA :: String -> IO ()
-warnA x =
-    -- Handle read errors get a respawn, already reported.
-    unless ("hGetLine" `isInfixOf` x) do
-        sty <- getsHS config
-        putmsg $ Fast (P.pack x) (warnings sty)
-        touchHS
+warnA x = do
+    sty <- getsHS config
+    putmsg $ Fast (P.pack x) (warnings sty)
+    touchHS
 

--- a/Core.hs
+++ b/Core.hs
@@ -75,7 +75,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
     now <- getMonoTime
     mode <- readState
 
-    threads <- sequence $ map forkIO
+    threads <- traverse forkIO
         [ mpgLoop
         , mpgInput readf
         , refreshLoop
@@ -85,14 +85,13 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
         , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
         ]
 
-    silentlyModifyHS $ \s -> s
+    silentlyModifyHS $ \st -> st
         { music        = fs
         , folders      = ds
         , size         = 1 + (snd . bounds $ fs)
         , cursor       = 0
         , current      = 0
         , mode         = mode
-        , uptime       = showTimeDiff now now
         , boottime     = now
         , config       = c
         , threads      }
@@ -106,7 +105,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
 ------------------------------------------------------------------------
 
--- | Uniform loop and thread handler (subtle, and requires exitImmediately)
+-- | Uniform loop and thread handler
 runForever :: IO () -> IO ()
 runForever fn = catch (forever fn) handler where
     handler :: SomeException -> IO ()
@@ -188,11 +187,9 @@ refreshLoop = do
 -- | The clock ticks once per minute, but check more often in case of drift.
 uptimeLoop :: IO ()
 uptimeLoop = runForever $ do
-    threadDelay delay
     now <- getMonoTime
     modifyHS_ $ \st -> st { uptime = showTimeDiff (boottime st) now }
-  where
-    delay = 5_000_000
+    threadDelay 3_000_000
 
 ------------------------------------------------------------------------
 
@@ -218,9 +215,7 @@ showTimeDiff = showTimeDiff_ False
 
 -- | Periodically wake up and redraw the clock
 clockLoop :: IO ()
-clockLoop = runForever $ threadDelay delay >> UI.refreshClock
-  where
-    delay = 200_000
+clockLoop = runForever $ threadDelay 125_000 *> UI.refreshClock
 
 ------------------------------------------------------------------------
 
@@ -357,6 +352,7 @@ blacklist = do
 
 ------------------------------------------------------------------------
 
+-- | Operates on HState and outputs maybe a track to play.
 type PlayOp = State HState (Maybe Int)
 
 -- | Play the song under the cursor or random if that one is playing

--- a/Core.hs
+++ b/Core.hs
@@ -43,14 +43,15 @@ import {-# SOURCE #-} Keymap (keyLoop)
 import qualified Data.ByteString.Char8 as P
 import qualified Data.Sequence as Seq
 
-import Control.Arrow            ((&&&))
 import Data.Array               ((!), bounds, Array)
+import Data.Tuple               (swap)
+import Control.Monad.State.Strict
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
                                  getXdgDirectory, XdgDirectory(..))
 import System.IO                (hPutStrLn, hGetLine, stderr, hFlush)
 import System.Process           (runInteractiveProcess, waitForProcess)
 import System.Clock             (TimeSpec(..), diffTimeSpec)
-import System.Random            (randomRIO)
+import System.Random            (randomR)
 import System.FilePath          ((</>))
 
 import System.Posix.Process     (exitImmediately)
@@ -98,7 +99,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     loadConfig
 
-    if mode == Random then playRandom else playCur
+    if mode == Random then runPlayOp playRandomOp else playCur
     when (not playNow) pause
 
     run         -- won't restart if this fails!
@@ -356,64 +357,78 @@ blacklist = do
 
 ------------------------------------------------------------------------
 
--- | Load and play the song under the cursor
+type PlayOp = State HState (Maybe Int)
+
+-- | Play the song under the cursor or random if that one is playing
+-- TODO these semantics are strange; maybe playNext instead of random?
 play :: IO ()
-play = do
-    (curr, curs) <- getsHS (current &&& cursor)
-    if curr == curs
-        then playRandom
-        else playAtN (const curs)
+play = runPlayOp do
+    HState { current, cursor } <- get
+    if current == cursor
+        then playRandomOp
+        else pure $ Just cursor
 
+-- | Play the song under the cursor (from the start)
 playCur :: IO ()
-playCur = playAtN . const =<< getsHS cursor
-
--- | Jump to a random song
-playRandom :: IO ()
-playRandom = playAtN . const =<< (\sz -> randomRIO (0, sz-1)) =<< getsHS size
+playCur = runPlayOp $ Just <$> gets cursor
 
 -- | Play the song before the current song, if we're not at the beginning
 -- If we're at the beginning, and loop mode is on, then loop to the end
 -- If we're in random mode, play the next random track
 playPrev :: IO ()
-playPrev = do
-    (mo, (sz, cur)) <- getsHS (mode &&& size &&& current)
-    case mo of
-        Random      -> playRandom
-        Single      -> pure ()
-        _ | cur > 0 -> playAtN (subtract 1)
-        Loop        -> playAtN (const (sz-1))
-        Once        -> pure ()
+playPrev = runPlayOp do
+    HState { mode, size, current } <- get
+    case mode of
+        Random  -> playRandomOp
+        Single  -> pure Nothing
+        _ | current > 0
+                -> pure $ Just $ current - 1
+        Loop    -> pure $ Just $ size - 1
+        Once    -> pure Nothing
 
 -- | Play the song following the current song, if we're not at the end
 -- If we're at the end, and loop mode is on, then loop to the start
 -- If we're in random mode, play the next random track
 playNext :: IO ()
-playNext = do
-    (mo, notLast) <- getsHS (mode &&& (\st -> current st < size st - 1))
-    case mo of
-        Random      -> playRandom
-        Single      -> pure ()
-        _ | notLast -> playAtN (+ 1)
-        Loop        -> playAtN (const 0)
-        Once        -> pure ()
+playNext = runPlayOp do
+    HState { mode, current, size } <- get
+    let next = current + 1
+    case mode of
+        Random  -> playRandomOp
+        Single  -> pure Nothing
+        _ | next < size
+                -> pure $ Just next
+        Loop    -> pure $ Just 0
+        Once    -> pure Nothing
+
+-- | Random song
+playRandomOp :: PlayOp
+playRandomOp = do
+    HState { size, randomGen } <- get
+    let (new, gen') = randomR (0, size-1) randomGen
+    modify' \st -> st { randomGen = gen' }
+    pure $ Just new
 
 -- | Generic next song selection
--- If the cursor and current are currently the same, continue that.
-playAtN :: (Int -> Int) -> IO ()
-playAtN fn = do
+-- If cursor is on current, drag it along.
+runPlayOp :: PlayOp -> IO ()
+runPlayOp op = do
     now <- getMonoTime
-    file <- modifyHS \st@HState{..} ->
-        let new = fn current
-            fe  = music ! new
-            f   = P.intercalate (P.singleton '/')
-                     [dname $ folders ! fdir fe, fbase fe]
-            st' = st { current = new
-                     , status  = Playing
-                     , cursor  = if current == cursor then new else cursor
-                     , playHist = Seq.take 36 $ (now, new) Seq.<| playHist
-                     }
-        in (st', f)
-    sendMpg $ Load file
+    mfile <- modifyHS $ swap . runState do
+        mnew <- op
+        forM mnew \new -> do
+            HState { .. } <- get
+            let fe = music ! new
+                f  = P.intercalate (P.singleton '/')
+                        [dname $ folders ! fdir fe, fbase fe]
+            modify' \st -> st
+                { current = new
+                , status  = Playing
+                , cursor  = if current == cursor then new else cursor
+                , playHist = Seq.take 36 $ (now, new) Seq.<| playHist
+                }
+            pure f
+    forM_ mfile $ sendMpg . Load
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -75,15 +75,15 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     threads <- sequence $ map forkIO
         [ mpgLoop
-        , mpgInput mpgReadf
+        , mpgInput readf
         , refreshLoop
         , clockLoop
         , uptimeLoop
         -- mpg321 uses stderr for @F messages
-        , if mp3Tool == "mpg321" then mpgInput mpgErrh else errorLoop
+        , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
         ]
 
-    silentlyModifyST $ \s -> s
+    silentlyModifyHS $ \s -> s
         { music        = fs
         , folders      = ds
         , size         = 1 + (snd . bounds $ fs)
@@ -97,7 +97,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     loadConfig
 
-    if mode == Random then modifySTM jumpToRandom else playCur
+    if mode == Random then modifyHSM jumpToRandom else playCur
     when (not playNow) pause
 
     run         -- won't restart if this fails!
@@ -143,27 +143,27 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
           Left (ex :: SomeException) ->
             warnA $ "Unable to start " ++ mp3Tool ++ ": " ++ show ex ++ "; retrying..."
 
-          Right (mpgWriteh, r, e, pid) -> do
+          Right (writeh, r, e, pid) -> do
             spawns <- readIORef spawnsRef
 
             when (spawns > 1) do
                 void $ takeMVar mpg
                 warnA $ "Started " ++ mp3Tool ++ " #" ++ show spawns
 
-            modifyST $ \st -> st
+            modifyHS_ $ \st -> st
                 { mpgPid    = Just pid
                 , status    = Stopped
                 , info      = Nothing
                 , id3       = Nothing
                 }
 
-            mpgReadf <- newFiltHandle r
-            mpgErrh <- newFiltHandle e
-            putMVar mpg Mpg { mpgReadf, mpgErrh, mpgWriteh }
+            readf <- newFiltHandle r
+            errh <- newFiltHandle e
+            putMVar mpg Mpg { readf, errh, writeh }
 
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
-            silentlyModifyST $ \st -> st { mpgPid = Nothing }
-            stop <- getsST doNotResuscitate
+            silentlyModifyHS $ \st -> st { mpgPid = Nothing }
+            stop <- getsHS doNotResuscitate
             when stop exitSuccess
             warnA $ "Restarting " ++ mppath ++ " (#" ++ show spawns ++ ")..."
             modifyIORef' spawnsRef (+ 1)
@@ -178,7 +178,7 @@ mpgLoop = newIORef (1 :: Integer) >>= \spawnsRef -> runForever do
 -- for it to be modified again.
 refreshLoop :: IO ()
 refreshLoop = do
-    mvar <- getsST modified
+    mvar <- getsHS modified
     runForever $ takeMVar mvar >> UI.refresh
 
 ------------------------------------------------------------------------
@@ -188,7 +188,7 @@ uptimeLoop :: IO ()
 uptimeLoop = runForever $ do
     threadDelay delay
     now <- getMonoTime
-    modifyST $ \st -> st { uptime = showTimeDiff (boottime st) now }
+    modifyHS_ $ \st -> st { uptime = showTimeDiff (boottime st) now }
   where
     delay = 5 * 1000 * 1000 -- refresh every 5 seconds
 
@@ -225,7 +225,7 @@ clockLoop = runForever $ threadDelay delay >> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    mpgErrh <$> readMVar mpg >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
+    errh <$> readMVar mpg >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
 
 ------------------------------------------------------------------------
 
@@ -253,16 +253,16 @@ run = runForever keyLoop
 -- | Close most things. Important to do all the jobs:
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
-    silentlyModifyST $ \st -> st { doNotResuscitate = True }
+    silentlyModifyHS $ \st -> st { doNotResuscitate = True }
     discardErrors writeState
-    mpid <- getsST mpgPid
+    mpid <- getsHS mpgPid
     whenJust mpid \pid -> do
         sendMpg Quit               -- ask politely
         void $ waitForProcess pid
 
     `finally`
 
-    do  isXterm <- getsST xterm
+    do  isXterm <- getsHS xterm
         UI.end isXterm
         when (isJust ms) $ hPutStrLn stderr (fromJust ms) >> hFlush stderr
         exitImmediately ExitSuccess
@@ -274,17 +274,17 @@ shutdown ms = do
 --
 handleMsg :: Msg -> IO ()
 handleMsg (T _)                = pure ()
-handleMsg (I i)                = modifyST $ \s -> s { info = Just i }
-handleMsg (F (File (Left  _))) = modifyST $ \s -> s { id3 = Nothing }
-handleMsg (F (File (Right i))) = modifyST $ \s -> s { id3 = Just i  }
+handleMsg (I i)                = modifyHS_ $ \s -> s { info = Just i }
+handleMsg (F (File (Left  _))) = modifyHS_ $ \s -> s { id3 = Nothing }
+handleMsg (F (File (Right i))) = modifyHS_ $ \s -> s { id3 = Just i  }
 
 handleMsg (S t) = do
-    modifyST $ \s -> s { status  = t }
+    modifyHS_ $ \s -> s { status  = t }
     when (t == Stopped) playNext   -- transition to next song
 
 handleMsg (R f) = do
-    silentlyModifyST \st -> st { clock = Just f }
-    getsST clockUpdate >>= flip when UI.refreshClock
+    silentlyModifyHS \st -> st { clock = Just f }
+    getsHS clockUpdate >>= flip when UI.refreshClock
 
 ------------------------------------------------------------------------
 --
@@ -306,20 +306,20 @@ seekStart = seek $ const 0
 -- | Generic seek
 seek :: (Frame -> Int) -> IO ()
 seek fn = do
-    f <- getsST clock
+    f <- getsHS clock
     case f of
         Nothing -> pure ()
         Just g  -> do
             sendMpg $ Jump (fn g)
             forceNextPacket         -- don't drop the next Frame.
-            silentlyModifyST $ \st -> st { clockUpdate = True }
+            silentlyModifyHS $ \st -> st { clockUpdate = True }
 
 
 ------------------------------------------------------------------------
 
 -- | Generic jump
 jumpFn :: (Int -> Int) -> IO ()
-jumpFn fn = modifyST \st ->
+jumpFn fn = modifyHS_ \st ->
     st { cursor = (fn (cursor st) `min` (size st - 1)) `max` 0 }
 
 -- | Move cursor up or down
@@ -343,24 +343,24 @@ jump = jumpFn . const
 -- | Jump to relative place, 0 to 1.
 jumpRel :: Float -> IO ()
 jumpRel r | r < 0 || r >= 1 = pure ()
-          | True = modifyST $ \st ->
+          | True = modifyHS_ $ \st ->
               st { cursor = floor $ fromIntegral (size st) * r }
 
 ------------------------------------------------------------------------
 
 -- | Load and play the song under the cursor
 play :: IO ()
-play = modifySTM $ \st ->
+play = modifyHSM $ \st ->
     if current st == cursor st
     then jumpToRandom st
     else playAtN st (const $ cursor st)
 
 playCur :: IO ()
-playCur = modifySTM $ \st -> playAtN st (const $ cursor st)
+playCur = modifyHSM $ \st -> playAtN st (const $ cursor st)
 
 blacklist :: IO ()
 blacklist = do
-    st <- getsST id
+    st <- getsHS id
     appendFile ".hmp3-delete" . (++"\n") . P.unpack $
         let fe = music st ! cursor st
         in P.intercalate (P.singleton '/') [dname $ folders st ! fdir fe, fbase fe]
@@ -373,7 +373,7 @@ jumpToRandom st = playAtN st . const =<< randomRIO (0, size st - 1)
 -- If we're at the beginning, and loop mode is on, then loop to the end
 -- If we're in random mode, play the next random track
 playPrev :: IO ()
-playPrev = modifySTM \st -> case mode st of
+playPrev = modifyHSM \st -> case mode st of
     Random -> jumpToRandom st
     Single -> pure st
     _ | current st > 0
@@ -385,7 +385,7 @@ playPrev = modifySTM \st -> case mode st of
 -- If we're at the end, and loop mode is on, then loop to the start
 -- If we're in random mode, play the next random track
 playNext :: IO ()
-playNext = modifySTM \st -> case mode st of
+playNext = modifyHSM \st -> case mode st of
     Random -> jumpToRandom st
     Single -> pure st
     _ | current st < size st - 1
@@ -423,7 +423,7 @@ pause = sendMpg Pause
 -- | Always pause
 forcePause :: IO ()
 forcePause = do
-    st <- getsST status
+    st <- getsHS status
     when (st == Playing) pause
 
 -- | Shutdown and exit
@@ -434,7 +434,7 @@ quit = shutdown
 
 -- | Move cursor to currently playing song
 jumpToPlaying :: IO ()
-jumpToPlaying = modifyST $ \st -> st { cursor = current st }
+jumpToPlaying = modifyHS_ $ \st -> st { cursor = current st }
 
 -- | Move cursor to first song in next directory (or wrap)
 jumpToNextDir, jumpToPrevDir :: IO ()
@@ -443,7 +443,7 @@ jumpToPrevDir = jumpToDir (\i _   -> max (i-1) 0)
 
 -- | Generic jump to dir
 jumpToDir :: (Int -> Int -> Int) -> IO ()
-jumpToDir fn = modifyST $ \st -> if size st == 0 then st else
+jumpToDir fn = modifyHS_ $ \st -> if size st == 0 then st else
     let i   = fdir (music st ! cursor st)
         len = 1 + (snd . bounds $ folders st)
         d   = fn i len
@@ -479,7 +479,7 @@ genericJumpToMatch :: Lookup a
                    -> IO ()
 
 genericJumpToMatch re sw k sel = do
-    found <- modifySTM_ $ \st -> pure do
+    found <- modifyHS $ \st -> do
         let mre = case re of
                 Nothing -> case regex st of
                     Nothing     -> Nothing
@@ -496,30 +496,30 @@ genericJumpToMatch re sw k sel = do
                 i:_ -> (st' { cursor = sel i st }, True)
                 _   -> (st', False)
 
-    unless found $ putmsg (Fast "No match found." defaultSty) *> touchST
+    unless found $ putmsg (Fast "No match found." defaultSty) *> touchHS
 
 ------------------------------------------------------------------------
 
 -- | Show/hide the help window
 toggleHelp :: IO ()
-toggleHelp = modifyST $ \st -> st { helpVisible = not (helpVisible st) }
+toggleHelp = modifyHS_ $ \st -> st { helpVisible = not (helpVisible st) }
 
 -- | Focus the minibuffer
 toggleFocus :: IO ()
-toggleFocus = modifyST $ \st -> st { miniFocused = not (miniFocused st) }
+toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
 
 -- | Show/hide the confirm exit modal
 toggleExit :: IO ()
-toggleExit = modifyST $ \st -> st { exitVisible = not (exitVisible st) }
+toggleExit = modifyHS_ $ \st -> st { exitVisible = not (exitVisible st) }
 
 -- | History on or off
 hideHist :: IO ()
-hideHist = modifyST $ \st -> st { histVisible = Nothing }
+hideHist = modifyHS_ $ \st -> st { histVisible = Nothing }
 
 showHist :: IO ()
 showHist = do
     now <- getMonoTime
-    modifyST $ \st -> st {
+    modifyHS_ $ \st -> st {
         helpVisible = False,
         histVisible = Just $ do
             (tm, ix) <- toList $ playHist st
@@ -528,7 +528,7 @@ showHist = do
 
 -- | Toggle the mode flag
 nextMode :: IO ()
-nextMode = modifyST $ \st -> st { mode = next (mode st) }
+nextMode = modifyHS_ $ \st -> st { mode = next (mode st) }
     where
         next v = if v == maxBound then minBound else succ v
 
@@ -542,7 +542,7 @@ writeState :: IO ()
 writeState = do
     dir <- getStatePath
     createDirectoryIfMissing True dir
-    mode <- getsST mode
+    mode <- getsHS mode
     writeFile (dir </> "mode") $ show mode ++ "\n"
 
 -- | Read mode state
@@ -581,10 +581,10 @@ loadConfig = do
             Just rsty -> do
                 let sty = buildStyle rsty
                 initcolours sty
-                modifyST $ \st -> st { config = sty }
+                modifyHS_ $ \st -> st { config = sty }
       else do
         initcolours defaultStyle
-        modifyST $ \st -> st { config = defaultStyle }
+        modifyHS_ $ \st -> st { config = defaultStyle }
     UI.resetui
 
 ------------------------------------------------------------------------
@@ -592,7 +592,7 @@ loadConfig = do
 
 -- TODO maybe shouldn't be silent?
 putmsg :: StringA -> IO ()
-putmsg s = silentlyModifyST $ \st -> st { minibuffer = s }
+putmsg s = silentlyModifyHS $ \st -> st { minibuffer = s }
 
 -- | Modify without triggering a refresh
 clrmsg :: IO ()
@@ -603,7 +603,7 @@ warnA :: String -> IO ()
 warnA x =
     -- Handle read errors get a respawn, already reported.
     unless ("hGetLine" `isInfixOf` x) do
-        sty <- getsST config
+        sty <- getsHS config
         putmsg $ Fast (P.pack x) (warnings sty)
-        touchST
+        touchHS
 

--- a/Core.hs
+++ b/Core.hs
@@ -142,7 +142,7 @@ mpgLoop = runForever do
         mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
         case mv of
           Left (ex :: SomeException) ->
-            warnA $ "Unable to start " ++ mppath ++ ": " ++ show ex ++ "; retrying..."
+            warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
           Right (writeh, r, e, pid) -> do
 
@@ -167,7 +167,7 @@ mpgLoop = runForever do
             stop <- getsHS doNotResuscitate
             when stop exitSuccess
             threadDelay 1_000_000  -- let threads spit errors
-            warnA $ "Restarting " ++ mppath ++ "..."
+            warnA $ "Restarting " ++ mppath ++ " ..."
 
         -- Slow spawn loops in case of trouble.
         threadDelay 4_000_000

--- a/Core.hs
+++ b/Core.hs
@@ -98,7 +98,7 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     loadConfig
 
-    if mode == Random then jumpToRandom else playCur
+    if mode == Random then playRandom else playCur
     when (not playNow) pause
 
     run         -- won't restart if this fails!
@@ -107,12 +107,12 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
 -- | Uniform loop and thread handler (subtle, and requires exitImmediately)
 runForever :: IO () -> IO ()
-runForever fn = catch (forever fn) handler
-    where
-        handler :: SomeException -> IO ()
-        handler e =
-            unless (exitTime e) $
-                (warnA . ("outer: " ++) . show) e >> runForever fn  -- reopen the catch
+runForever fn = catch (forever fn) handler where
+    handler :: SomeException -> IO ()
+    handler e = unless (exitTime e) do
+        warnA $ "outer: " ++ show e
+        threadDelay 50_000
+        runForever fn
 
 -- | Generic handler
 -- I don't know why these are ignored, but preserving old logic.
@@ -160,6 +160,7 @@ mpgLoop = runForever do
             when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
 
+            -- Must be in this order or risk shutdown deadlock!
             silentlyModifyHS $ \st -> st { mpgPid = Nothing }
             void $ takeMVar mpg
 
@@ -225,7 +226,7 @@ clockLoop = runForever $ threadDelay delay >> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    readMVar mpg <&> errh >>= hGetLine . filtHandle >>= (warnA . ("mpg: "++))
+    readMVar mpg <&> errh >>= hGetLine . filtHandle >>= (warnA . ("mpg: " ++))
 
 ------------------------------------------------------------------------
 
@@ -238,7 +239,7 @@ mpgInput field = runForever $ do
     res <- parser =<< field <$> readMVar mpg
     case res of
         Right m       -> handleMsg m
-        Left (Just e) -> (warnA . ("read: "++) . show) e
+        Left (Just e) -> (warnA . ("read: " ++) . show) e
         _             -> pure ()
 
 ------------------------------------------------------------------------
@@ -345,19 +346,7 @@ jumpRel r | r < 0 || r >= 1 = pure ()
           | True = modifyHS_ $ \st ->
               st { cursor = floor $ fromIntegral (size st) * r }
 
-------------------------------------------------------------------------
-
--- | Load and play the song under the cursor
-play :: IO ()
-play = do
-    (curr, curs) <- getsHS (current &&& cursor)
-    if curr == curs
-        then jumpToRandom
-        else playAtN (const curs)
-
-playCur :: IO ()
-playCur = playAtN . const =<< getsHS cursor
-
+-- | Experimental feature concept.
 blacklist :: IO ()
 blacklist = do
     st <- getsHS id
@@ -365,9 +354,22 @@ blacklist = do
         let fe = music st ! cursor st
         in P.intercalate (P.singleton '/') [dname $ folders st ! fdir fe, fbase fe]
 
+------------------------------------------------------------------------
+
+-- | Load and play the song under the cursor
+play :: IO ()
+play = do
+    (curr, curs) <- getsHS (current &&& cursor)
+    if curr == curs
+        then playRandom
+        else playAtN (const curs)
+
+playCur :: IO ()
+playCur = playAtN . const =<< getsHS cursor
+
 -- | Jump to a random song
-jumpToRandom :: IO ()
-jumpToRandom = playAtN . const =<< (\sz -> randomRIO (0, sz-1)) =<< getsHS size
+playRandom :: IO ()
+playRandom = playAtN . const =<< (\sz -> randomRIO (0, sz-1)) =<< getsHS size
 
 -- | Play the song before the current song, if we're not at the beginning
 -- If we're at the beginning, and loop mode is on, then loop to the end
@@ -376,7 +378,7 @@ playPrev :: IO ()
 playPrev = do
     (mo, (sz, cur)) <- getsHS (mode &&& size &&& current)
     case mo of
-        Random      -> jumpToRandom
+        Random      -> playRandom
         Single      -> pure ()
         _ | cur > 0 -> playAtN (subtract 1)
         Loop        -> playAtN (const (sz-1))
@@ -389,7 +391,7 @@ playNext :: IO ()
 playNext = do
     (mo, notLast) <- getsHS (mode &&& (\st -> current st < size st - 1))
     case mo of
-        Random      -> jumpToRandom
+        Random      -> playRandom
         Single      -> pure ()
         _ | notLast -> playAtN (+ 1)
         Loop        -> playAtN (const 0)

--- a/Core.hs
+++ b/Core.hs
@@ -146,17 +146,19 @@ mpgLoop = runForever do
 
           Right (writeh, r, e, pid) -> do
 
-            modifyHS_ $ \st -> st
+            ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { mpgPid    = Just pid
                 , status    = Stopped
                 , info      = Nothing
                 , id3       = Nothing
-                }
+                , spawns    = sp
+                }, sp)
 
             readf <- newFiltHandle r
             errh <- newFiltHandle e
             putMVar mpg Mpg { readf, errh, writeh }
 
+            when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
 
             silentlyModifyHS $ \st -> st { mpgPid = Nothing }
@@ -169,7 +171,6 @@ mpgLoop = runForever do
 
         -- Slow spawn loops in case of trouble.
         threadDelay 4_000_000
-        warnA "Ready" -- optimistic but will get overwritten on error
 
 
 ------------------------------------------------------------------------

--- a/FastIO.hs
+++ b/FastIO.hs
@@ -8,14 +8,10 @@ module FastIO where
 
 import Base
 
-import Syntax                   (Pretty(ppr))
-
 import qualified Data.ByteString.Char8 as B
 
 import System.Posix.Files.ByteString
 import System.Posix.Directory.ByteString
-
-import System.IO                (hFlush)
 
 ------------------------------------------------------------------------
 
@@ -83,11 +79,6 @@ checkF (FiltHandle _ ir) = do
 
 isReadable :: ByteString -> IO Bool
 isReadable fp = fileAccess fp True False False
-
--- ---------------------------------------------------------------------
--- | Send a msg over the channel to the decoder
-send :: Pretty a => Handle -> a -> IO ()
-send h m = B.hPut h (ppr m) >> B.hPut h "\n" >> hFlush h
 
 ------------------------------------------------------------------------ 
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -18,7 +18,7 @@ import Base hiding ((!?))
 
 import Core
 import Config       (package)
-import State        (getsST, touchST, modifyST, HState(histVisible, searchHist))
+import State        (getsHS, touchHS, modifyHS_, HState(histVisible, searchHist))
 import Style        (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
 
@@ -48,18 +48,18 @@ keyLoop = go mainMode where
 
 mainMode :: KeyMap
 mainMode = KeyMap dispatch where
-    dispatch 'q'  = forcePause *> toggleExit *> touchST $> confirmQuitMode
+    dispatch 'q'  = forcePause *> toggleExit *> touchHS $> confirmQuitMode
     dispatch c
         | c `elem` ['/', '?', '\\', '|']
                                = enterSearch c
-        | c `elem` ['H', ';']  = showHist *> touchST $> historyMode
+        | c `elem` ['H', ';']  = showHist *> touchHS $> historyMode
         | c >= '1' && c <= '9' =
             jumpRel (0.1 * fromIntegral (fromEnum c - 48)) $> mainMode
         | True                 = sequence_ (M.lookup c keyMap) $> mainMode
 
     enterSearch stype = do
         toggleFocus
-        hist <- getsST searchHist
+        hist <- getsHS searchHist
         searchMode stype $ Zipper "" hist []
 
 
@@ -76,7 +76,7 @@ searchMode stype = step where
     step z = renderSearch stype z $> KeyMap (`dispatch` z)
 
     dispatch c z
-        | c == '\ESC'      = clrmsg *> touchST *> leave
+        | c == '\ESC'      = clrmsg *> touchHS *> leave
         | c `elem` enter'  = commit z
         | c `elem` delete' = step $ zipEdit dropLast z
         | k == KeyUp       = step $ zipUp z
@@ -86,19 +86,19 @@ searchMode stype = step where
         | otherwise        = step $ zipEdit (++ [c]) z
       where k = charToKey c
 
-    commit (Zipper []  _ _) = clrmsg *> touchST *> leave
+    commit (Zipper []  _ _) = clrmsg *> touchHS *> leave
     commit (Zipper pat _ _) = do
         let jumpy = if stype `elem` ['/', '?']
                     then jumpToMatchFile else jumpToMatchDir
         jumpy (Just pat) (stype `elem` ['/', '\\'])
-        modifyST \st -> st { searchHist = pat : filter (/= pat) (searchHist st) }
+        modifyHS_ \st -> st { searchHist = pat : filter (/= pat) (searchHist st) }
         leave
 
     histDelete z = do
         let z' = case z of
                 Zipper _ b (pv:rest) -> Zipper pv b rest
                 Zipper _ b _         -> Zipper "" b []
-        modifyST \st -> st { searchHist = filter (/= cur z) (searchHist st) }
+        modifyHS_ \st -> st { searchHist = filter (/= cur z) (searchHist st) }
         step z'
 
     leave = toggleFocus $> mainMode
@@ -106,7 +106,7 @@ searchMode stype = step where
 renderSearch :: Char -> Zipper -> IO ()
 renderSearch prefix z = do
     putmsg $ Fast (P.pack (prefix : cur z)) defaultSty
-    touchST
+    touchHS
 
 dropLast :: [a] -> [a]
 dropLast [] = []
@@ -128,10 +128,10 @@ zipDown z                       = z
 historyMode :: KeyMap
 historyMode = KeyMap \c -> do
     for_ (M.lookup c historyKeys) \k -> do
-        phm <- getsST histVisible
+        phm <- getsHS histVisible
         for_ (phm >>= (!? k)) (jump . fst . snd)
     hideHist
-    touchST
+    touchHS
     pure mainMode
   where
     historyKeys :: M.Map Char Int
@@ -147,7 +147,7 @@ historyMode = KeyMap \c -> do
 confirmQuitMode :: KeyMap
 confirmQuitMode = KeyMap \case
     'y' -> quit Nothing $> undefined -- quit never returns
-    _   -> toggleExit *> touchST $> mainMode
+    _   -> toggleExit *> touchHS $> mainMode
 
 
 ------------------------------------------------------------------------

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -146,7 +146,7 @@ historyMode = KeyMap \c -> do
 
 confirmQuitMode :: KeyMap
 confirmQuitMode = KeyMap \case
-    'y' -> quit Nothing $> undefined -- quit never returns
+    'y' -> shutdown Nothing $> undefined -- shutdown never returns
     _   -> toggleExit *> touchHS $> mainMode
 
 

--- a/State.hs
+++ b/State.hs
@@ -71,8 +71,14 @@ data HState = HState {
 --
 -- | The initial state
 --
-emptySt :: HState
-emptySt = HState {
+newEmptyHS :: IO HState
+newEmptyHS = do
+    modified <- newEmptyMVar
+    writeh   <- newEmptyMVar
+    errh     <- newEmptyMVar
+    readf    <- newEmptyMVar
+    drawLock <- newMVar ()
+    pure HState {
         music        = listArray (0,0) []
        ,folders      = listArray (0,0) []
 
@@ -81,10 +87,10 @@ emptySt = HState {
        ,cursor       = 0
 
        ,threads      = []
-       ,modified     = unsafePerformIO newEmptyMVar
-       ,writeh       = unsafePerformIO newEmptyMVar
-       ,errh         = unsafePerformIO newEmptyMVar
-       ,readf        = unsafePerformIO newEmptyMVar
+       ,modified
+       ,writeh
+       ,errh
+       ,readf
 
        ,mp3pid       = Nothing
        ,clock        = Nothing
@@ -105,17 +111,17 @@ emptySt = HState {
        ,config       = Config.defaultStyle
        ,boottime     = 0
        ,status       = Stopped
-       ,mode         = Once
+       ,mode         = minBound
        ,minibuffer   = Fast mempty defaultSty
        ,uptime       = mempty
-       ,drawLock     = unsafePerformIO (newMVar ())
+       ,drawLock
     }
 
 --
--- | A global variable holding the state. Todo StateT
+-- | A global variable holding the state.
 --
 state :: MVar HState
-state = unsafePerformIO $ newMVar emptySt
+state = unsafePerformIO $ newMVar =<< newEmptyHS
 {-# NOINLINE state #-}
 
 ------------------------------------------------------------------------

--- a/State.hs
+++ b/State.hs
@@ -9,8 +9,8 @@ module State where
 
 import Base
 
-import FastIO (FiltHandle(..))
-import Syntax                   (Status(Stopped), Mode(..), Frame, Info,Id3)
+import FastIO (FiltHandle(..), send)
+import Syntax                   (Status(Stopped), Mode(..), Frame, Info, Id3, Pretty)
 import Tree                     (FileArray, DirArray)
 import Style                    (StringA(Fast), defaultSty, UIStyle)
 import qualified Config (defaultStyle)
@@ -38,10 +38,7 @@ data HState = HState {
        ,cursor          :: !Int                  -- mp3 under the cursor
        ,clock           :: !(Maybe Frame)        -- current clock value
        ,clockUpdate     :: !Bool
-       ,mp3pid          :: !(Maybe ProcessHandle) -- pid of decoder
-       ,writeh          :: !(MVar Handle)        --  handle to mp3 (should be MVars?)
-       ,errh            :: !(MVar FiltHandle)    --  error handle to mp3
-       ,readf           :: !(MVar FiltHandle)    -- r/w pipe to mp3
+       ,mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
        ,threads         :: ![ThreadId]           -- all our threads
        ,id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
        ,info            :: !(Maybe Info)         -- mp3 info
@@ -74,9 +71,6 @@ data HState = HState {
 newEmptyHS :: IO HState
 newEmptyHS = do
     modified <- newEmptyMVar
-    writeh   <- newEmptyMVar
-    errh     <- newEmptyMVar
-    readf    <- newEmptyMVar
     drawLock <- newMVar ()
     pure HState {
         music        = listArray (0,0) []
@@ -88,11 +82,8 @@ newEmptyHS = do
 
        ,threads      = []
        ,modified
-       ,writeh
-       ,errh
-       ,readf
 
-       ,mp3pid       = Nothing
+       ,mpgPid       = Nothing
        ,clock        = Nothing
        ,info         = Nothing
        ,id3          = Nothing
@@ -124,16 +115,26 @@ state :: MVar HState
 state = unsafePerformIO $ newMVar =<< newEmptyHS
 {-# NOINLINE state #-}
 
+data Mpg = Mpg
+    { mpgWriteh :: !Handle
+    , mpgReadf  :: !FiltHandle
+    , mpgErrh   :: !FiltHandle
+    }
+
+mpg :: MVar Mpg
+mpg = unsafePerformIO newEmptyMVar
+{-# NOINLINE mpg #-}
+
+-- Single point that needs to serialize: writing to the pipe.
+sendMpg :: Pretty a => a -> IO ()
+sendMpg m = withMVar mpg \m' -> send (mpgWriteh m') m
+
 ------------------------------------------------------------------------
 -- state accessor functions
 
 -- | Access a component of the state with a projection function
 getsST :: (HState -> a) -> IO a
-getsST f = withST (pure . f)
-
--- | Perform a (read-only) IO action on the state
-withST :: (HState -> IO a) -> IO a
-withST f = readMVar state >>= f
+getsST f = f <$> readMVar state
 
 -- | Modify the state with a pure function
 silentlyModifyST :: (HState -> HState) -> IO ()
@@ -158,7 +159,7 @@ touchST = withMVar state \st -> void $ tryPutMVar (modified st) ()
 
 forceNextPacket :: IO ()
 forceNextPacket = do
-  fh <- readMVar =<< getsST readf
+  fh <- mpgReadf <$> readMVar mpg
   writeIORef (frameCount fh) 0
 
 withDrawLock :: IO () -> IO ()

--- a/State.hs
+++ b/State.hs
@@ -34,9 +34,9 @@ data HState = HState {
        ,cursor          :: !Int                  -- mp3 under the cursor
        ,clock           :: !(Maybe Frame)        -- current clock value
        ,clockUpdate     :: !Bool
-       ,randomGen       :: StdGen                -- random seed
+       ,randomGen       :: !StdGen               -- random seed
        ,mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
-       ,spawns          :: Integer               -- count of decoder spawns
+       ,spawns          :: !Integer              -- count of decoder spawns
        ,threads         :: ![ThreadId]           -- all our threads
        ,id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
        ,info            :: !(Maybe Info)         -- mp3 info
@@ -50,10 +50,10 @@ data HState = HState {
        ,uptime          :: !ByteString
        ,boottime        :: !TimeSpec
        ,regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
-       ,searchHist      :: [String]              -- history of searches
+       ,searchHist      :: ![String]             -- history of searches
        ,xterm           :: !Bool
        ,doNotResuscitate :: !Bool                -- should we just let mpg123 die?
-       ,playHist        :: Seq (TimeSpec, Int)  -- limited history of songs played
+       ,playHist        :: !(Seq (TimeSpec, Int)) -- limited history of songs played
        ,config          :: !UIStyle             -- config values
 
        ,modified        :: !(MVar ())           -- Set when redrawable components of 

--- a/State.hs
+++ b/State.hs
@@ -124,7 +124,7 @@ mpg = unsafePerformIO newEmptyMVar
 
 sendMpg :: Pretty a => a -> IO ()
 sendMpg s = withMVar mpg $ (. writeh) \h ->
-    hPut h (ppr s) >> hPut h "\n" >> hFlush h  -- XXX NoBuffering?
+    hPut h (ppr s) >> hPut h "\n" >> hFlush h
 
 ------------------------------------------------------------------------
 -- state accessor functions

--- a/State.hs
+++ b/State.hs
@@ -9,16 +9,18 @@ module State where
 
 import Base
 
-import FastIO (FiltHandle(..), send)
-import Syntax                   (Status(Stopped), Mode(..), Frame, Info, Id3, Pretty)
+import FastIO (FiltHandle(..))
+import Syntax                   (Status(Stopped), Mode(..), Frame, Info, Id3, Pretty(ppr))
 import Tree                     (FileArray, DirArray)
 import Style                    (StringA(Fast), defaultSty, UIStyle)
 import qualified Config (defaultStyle)
 
 import Text.Regex.PCRE.Light    (Regex)
 import Data.Array               (listArray)
+import Data.ByteString          (hPut)
 import Data.Sequence            (Seq)
 import System.Clock             (TimeSpec(..))
+import System.IO                (hFlush)
 import System.Process           (ProcessHandle)
 
 
@@ -118,9 +120,9 @@ mpg :: MVar Mpg
 mpg = unsafePerformIO newEmptyMVar
 {-# NOINLINE mpg #-}
 
--- Single point that needs to serialize: writing to the pipe.
 sendMpg :: Pretty a => a -> IO ()
-sendMpg x = withMVar mpg \m -> send (writeh m) x
+sendMpg s = withMVar mpg $ (. writeh) \h ->
+    hPut h (ppr s) >> hPut h "\n" >> hFlush h  -- XXX NoBuffering?
 
 ------------------------------------------------------------------------
 -- state accessor functions

--- a/State.hs
+++ b/State.hs
@@ -22,6 +22,7 @@ import Data.Sequence            (Seq)
 import System.Clock             (TimeSpec(..))
 import System.IO                (hFlush)
 import System.Process           (ProcessHandle)
+import System.Random
 
 
 -- | The editor state type
@@ -33,6 +34,7 @@ data HState = HState {
        ,cursor          :: !Int                  -- mp3 under the cursor
        ,clock           :: !(Maybe Frame)        -- current clock value
        ,clockUpdate     :: !Bool
+       ,randomGen       :: StdGen                -- random seed
        ,mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
        ,spawns          :: Integer               -- count of decoder spawns
        ,threads         :: ![ThreadId]           -- all our threads
@@ -44,7 +46,7 @@ data HState = HState {
        ,histVisible     :: !(Maybe [(ByteString, (Int, ByteString))]) -- history pop-up if shown
        ,exitVisible     :: !Bool                 -- confirm exit modal shown
        ,miniFocused     :: !Bool                 -- is the mini buffer focused?
-       ,mode            :: !Mode                 -- random mode
+       ,mode            :: !Mode
        ,uptime          :: !ByteString
        ,boottime        :: !TimeSpec
        ,regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
@@ -66,8 +68,9 @@ data HState = HState {
 --
 newEmptyHS :: IO HState
 newEmptyHS = do
-    modified <- newEmptyMVar
-    drawLock <- newMVar ()
+    modified  <- newEmptyMVar
+    drawLock  <- newMVar ()
+    randomGen <- newStdGen
     pure HState {
         music        = listArray (0,0) []
        ,folders      = listArray (0,0) []
@@ -95,6 +98,7 @@ newEmptyHS = do
        ,xterm            = False
        ,doNotResuscitate = False    -- mpg123 should be restarted
 
+       ,randomGen
        ,playHist     = mempty
        ,config       = Config.defaultStyle
        ,boottime     = 0

--- a/State.hs
+++ b/State.hs
@@ -34,6 +34,7 @@ data HState = HState {
        ,clock           :: !(Maybe Frame)        -- current clock value
        ,clockUpdate     :: !Bool
        ,mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
+       ,spawns          :: Integer               -- count of decoder spawns
        ,threads         :: ![ThreadId]           -- all our threads
        ,id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
        ,info            :: !(Maybe Info)         -- mp3 info
@@ -79,6 +80,7 @@ newEmptyHS = do
        ,modified
 
        ,mpgPid       = Nothing
+       ,spawns       = 0
        ,clock        = Nothing
        ,info         = Nothing
        ,id3          = Nothing

--- a/State.hs
+++ b/State.hs
@@ -22,13 +22,6 @@ import System.Clock             (TimeSpec(..))
 import System.Process           (ProcessHandle)
 
 
-------------------------------------------------------------------------
--- A state monad over IO would be another option.
-
--- type ST = StateT HState IO
-
-------------------------------------------------------------------------
-
 -- | The editor state type
 data HState = HState {
         music           :: !FileArray
@@ -111,14 +104,14 @@ newEmptyHS = do
 --
 -- | A global variable holding the state.
 --
-state :: MVar HState
-state = unsafePerformIO $ newMVar =<< newEmptyHS
-{-# NOINLINE state #-}
+hState :: MVar HState
+hState = unsafePerformIO $ newMVar =<< newEmptyHS
+{-# NOINLINE hState #-}
 
 data Mpg = Mpg
-    { mpgWriteh :: !Handle
-    , mpgReadf  :: !FiltHandle
-    , mpgErrh   :: !FiltHandle
+    { writeh :: !Handle
+    , readf  :: !FiltHandle
+    , errh   :: !FiltHandle
     }
 
 mpg :: MVar Mpg
@@ -127,43 +120,43 @@ mpg = unsafePerformIO newEmptyMVar
 
 -- Single point that needs to serialize: writing to the pipe.
 sendMpg :: Pretty a => a -> IO ()
-sendMpg m = withMVar mpg \m' -> send (mpgWriteh m') m
+sendMpg x = withMVar mpg \m -> send (writeh m) x
 
 ------------------------------------------------------------------------
 -- state accessor functions
 
 -- | Access a component of the state with a projection function
-getsST :: (HState -> a) -> IO a
-getsST f = f <$> readMVar state
+getsHS :: (HState -> a) -> IO a
+getsHS f = f <$> readMVar hState
 
 -- | Modify the state with a pure function
-silentlyModifyST :: (HState -> HState) -> IO ()
-silentlyModifyST  f = modifyMVar_ state (pure . f)
+silentlyModifyHS :: (HState -> HState) -> IO ()
+silentlyModifyHS  f = modifyMVar_ hState (pure . f)
 
 ------------------------------------------------------------------------
 
-modifyST :: (HState -> HState) -> IO ()
-modifyST f = silentlyModifyST f <* touchST
+modifyHS_ :: (HState -> HState) -> IO ()
+modifyHS_ f = silentlyModifyHS f <* touchHS
 
 -- | Modify the state with an IO action, triggering a refresh
-modifySTM :: (HState -> IO HState) -> IO ()
-modifySTM f = modifyMVar_ state f <* touchST
+modifyHSM :: (HState -> IO HState) -> IO ()
+modifyHSM f = modifyMVar_ hState f <* touchHS
 
--- | Modify the state with an IO action, returning a value
-modifySTM_ :: (HState -> IO (HState,a)) -> IO a
-modifySTM_ f = modifyMVar state f <* touchST
+-- | Modify the state returning a value
+modifyHS :: (HState -> (HState, a)) -> IO a
+modifyHS f = modifyMVar hState (pure . f) <* touchHS
 
 -- | Trigger a refresh. This is the only way to update the screen
-touchST :: IO ()
-touchST = withMVar state \st -> void $ tryPutMVar (modified st) ()
+touchHS :: IO ()
+touchHS = withMVar hState \st -> void $ tryPutMVar (modified st) ()
 
 forceNextPacket :: IO ()
 forceNextPacket = do
-  fh <- mpgReadf <$> readMVar mpg
+  fh <- readf <$> readMVar mpg
   writeIORef (frameCount fh) 0
 
 withDrawLock :: IO () -> IO ()
 withDrawLock io = do
-    lock <- getsST drawLock
+    lock <- getsHS drawLock
     withMVar lock $ const io
 

--- a/State.hs
+++ b/State.hs
@@ -133,20 +133,14 @@ getsHS f = f <$> readMVar hState
 silentlyModifyHS :: (HState -> HState) -> IO ()
 silentlyModifyHS  f = modifyMVar_ hState (pure . f)
 
-------------------------------------------------------------------------
-
 modifyHS_ :: (HState -> HState) -> IO ()
 modifyHS_ f = silentlyModifyHS f <* touchHS
-
--- | Modify the state with an IO action, triggering a refresh
-modifyHSM :: (HState -> IO HState) -> IO ()
-modifyHSM f = modifyMVar_ hState f <* touchHS
 
 -- | Modify the state returning a value
 modifyHS :: (HState -> (HState, a)) -> IO a
 modifyHS f = modifyMVar hState (pure . f) <* touchHS
 
--- | Trigger a refresh. This is the only way to update the screen
+-- | Trigger a refresh. This is the only way to update the screen.
 touchHS :: IO ()
 touchHS = withMVar hState \st -> void $ tryPutMVar (modified st) ()
 

--- a/UI.hs
+++ b/UI.hs
@@ -155,7 +155,7 @@ resizeui = Draw $ void $ do
     do
         -- not sure I need all these...
         Curses.nl True
-        Curses.leaveOk True
+        _ <- Curses.leaveOk True
         Curses.noDelay Curses.stdScr False
         Curses.cBreak True
         -- Curses.meta stdScr True -- not in module

--- a/UI.hs
+++ b/UI.hs
@@ -68,7 +68,7 @@ start = do
         case thisterm of 
             Just "vt220" -> setEnv "TERM" "xterm-color"
             Just t | "xterm" `isPrefixOf` t 
-                   -> silentlyModifyST $ \st -> st { xterm = True }
+                   -> silentlyModifyHS $ \st -> st { xterm = True }
             _ -> pure ()
 
     Curses.initCurses
@@ -559,7 +559,7 @@ spaces = flip P.replicate ' '
 --
 redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
-   st      <- getsST id
+   st      <- getsHS id
    let fr = clock st
    (h, w) <- screenSize
    let sz = Size h w
@@ -601,7 +601,7 @@ renderModals s sz = do
 redraw :: Draw
 redraw = Draw $ discardErrors do
    -- linux ncurses, in particular, seems to complain a lot. this is an easy solution
-   s <- getsST id    -- another refresh could be triggered?
+   s <- getsHS id    -- another refresh could be triggered?
    let f = clock s
    (h, w) <- screenSize
    let sz = Size h w

--- a/UI.hs
+++ b/UI.hs
@@ -101,8 +101,9 @@ nocursor = Draw $ discardErrors $ void $ Curses.cursSet Curses.CursorInvisible
 -- | Clean up and go home. Refresh is needed on linux. grr.
 --
 end :: Bool -> IO ()
-end isXterm = do when isXterm $ setXtermTitle ["xterm"]
-                 Curses.endWin
+end isXterm = withDrawLock do
+    when isXterm $ setXtermTitle ["xterm"]
+    Curses.endWin
 
 --
 -- | Suspend the program

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -37,7 +37,8 @@ common opts
       MultiWayIf
       StandaloneDeriving
       NumericUnderscores
-  ghc-options: -Wall -funbox-strict-fields -Wno-unused-do-bind
+      NamedFieldPuns
+  ghc-options: -Wall -funbox-strict-fields
 
 library
   import: opts


### PR DESCRIPTION
This PR focuses on the dispensation of the mpg123 sub-process and its handlers, and fixes several state/concurrency bugs and infelicities:

*  The sub-process handlers are moved out of HState into their own top-level MVar.  This is a start of a move away from monolithic state.   `errh` might be better named `errf` since it's a `FiltHandle`, but in light of #82 it may soon be a mere handle again, so leaving.
*  There is now a `sendMpg` to send to the handle.  The more general `send` is not needed and so is assimilated.
*  The above means that starts/restarts reuse the said MVar instead of creating new ones, which was a broken model that caused a race condition which had been hacked around.  With these changes, restarts should be clean and all starts unracy.  I tested by writing a script that killed `mpg123`s once a second (also reducing the `threadDelays`s), and let it run killing dozens.  The player worked without issue even after this slaughter.
*  The `*ST` accessors are renamed to `*HS`, to avoid muddling with the standard ST monad.  The misleadingly named `withST` is eliminated.  The underscore convention is flipped per Haskell practice.  The top-level `state` became `hState`.
*  The `play*` functions are refactored and `seek` rewritten so that I/O is not done while the HState is held ("locked"), preventing UI blocks on I/O.  HState accessors that use `IO` while holding are removed, so the code can be statically seen to no longer do this.  In principle, there may be future features that require such I/O; that bridge will be crossed then.
*  A random number generator is put into HState so randomness can be gotten from state without needing `IO`.
*  Lots of little "cosmetic" (code, not the app) improvements.

Other changes, of rough increasing tangentiality:

*  The `unused-do-bind` warning is turned on.  I had once found it noisy, but a situation arose where it would've saved me wasted time.  Code is adjusted.
*  The empty HState is now a `newEmptyHS :: IO HState` instead of being built with `unsafePerformIO`s.  I already had a notion to do this to scope unsafeness, but a nasty bug it caused showed it to be vital.
*  HState includes an mpg123 spawn count, displayed on restart.  I added the count for a different reason, but then it was no longer needed; but then I decided it was a nice touch.
*  Throw loops are throttled in `runForever` so a failure won't spike CPU.
*  Some in-app warnings/errors are tagged with thread info, so I can see where they came from.
*  `quit` and `shutdown` are the same, so the former is dropped.
*  I wrapped `UI.end` in a `withDrawLock`.  I have occasionally gotten glitchy shutdowns over the years, and I suspect this will fix.
*  The music clock is updated much more frequently.  It's been 20 years, computers are faster.  I also slightly sped the uptime indicator.