### PR TITLE
Style: replace fake RGB colours with an intensity+hue model.

### DIFF
--- a/Config.hs
+++ b/Config.hs
@@ -75,4 +75,3 @@ versinfo  = package ++ " v" ++ showVersion version
 
 help :: String
 help = "- curses-based MP3 player"
-

--- a/Config.hs
+++ b/Config.hs
@@ -9,47 +9,47 @@ import Style
 import Paths_hmp3_ng (version)
 
 defaultStyle :: UIStyle
-defaultStyle  = UIStyle { window     = Style defaultfg    defaultbg
-                        , titlebar   = Style brightwhite  green
-                        , selected   = Style blue         defaultbg
-                        , cursors    = Style black        cyan
-                        , combined   = Style brightwhite  cyan
-                        , warnings   = Style red          defaultbg
-                        , modals     = Style black        white
-                        , blockcursor= Style black        red
-                        , progress   = Style cyan         white }
+defaultStyle  = UIStyle { window     = style "default"      "default"
+                        , titlebar   = style "brightwhite"  "green"
+                        , selected   = style "blue"         "default"
+                        , cursors    = style "black"        "cyan"
+                        , combined   = style "brightwhite"  "cyan"
+                        , warnings   = style "red"          "default"
+                        , modals     = style "black"        "white"
+                        , blockcursor= style "black"        "red"
+                        , progress   = style "cyan"         "white" }
 
 -- | A style more suitable for light backgrounds (used if HMP_HAS_LIGHT_BG=true)
 lightBgStyle :: UIStyle
 lightBgStyle =
-           defaultStyle { selected   = Style darkblue     defaultbg
-                        , warnings   = Style darkred      defaultbg }
+           defaultStyle { selected   = style "darkblue"     "default"
+                        , warnings   = style "darkred"      "default" }
 
 --
 -- | Another style for dark backgrounds, reminiscent of mutt
 --
 muttStyle :: UIStyle
-muttStyle   = UIStyle { window     = Style brightwhite  black
-                      , titlebar   = Style green        blue
-                      , selected   = Style brightwhite  black
-                      , cursors    = Style black        cyan
-                      , combined   = Style black        cyan
-                      , warnings   = Style brightwhite  red
-                      , modals     = Style black        cyan
-                      , blockcursor= Style black        darkred
-                      , progress   = Style cyan         white  }
+muttStyle = UIStyle { window     = style "brightwhite"  "black"
+                    , titlebar   = style "green"        "blue"
+                    , selected   = style "brightwhite"  "black"
+                    , cursors    = style "black"        "cyan"
+                    , combined   = style "black"        "cyan"
+                    , warnings   = style "brightwhite"  "red"
+                    , modals     = style "black"        "cyan"
+                    , blockcursor= style "black"        "darkred"
+                    , progress   = style "cyan"         "white"  }
 
 bwStyle :: UIStyle
 bwStyle = UIStyle {
-        window      = Style defaultfg   defaultbg
-       ,titlebar    = Style reversefg   reversebg
-       ,selected    = Style brightwhite defaultbg
-       ,cursors     = Style reversefg   reversebg
-       ,combined    = Style reversefg   reversebg
-       ,warnings    = Style reversefg   reversebg
-       ,modals      = Style reversefg   reversebg
-       ,blockcursor = Style reversefg   reversebg
-       ,progress    = Style reversefg   reversebg
+        window      = style "default"     "default"
+       ,titlebar    = style "reverse"     "reverse"
+       ,selected    = style "brightwhite" "default"
+       ,cursors     = style "reverse"     "reverse"
+       ,combined    = style "reverse"     "reverse"
+       ,warnings    = style "reverse"     "reverse"
+       ,modals      = style "reverse"     "reverse"
+       ,blockcursor = style "reverse"     "reverse"
+       ,progress    = style "reverse"     "reverse"
     }
 
 ------------------------------------------------------------------------
@@ -62,3 +62,4 @@ versinfo  = package ++ " v" ++ showVersion version
 
 help :: String
 help = "- curses-based MP3 player"
+

--- a/Config.hs
+++ b/Config.hs
@@ -4,9 +4,22 @@
 
 module Config where
 
+import qualified Data.Map as M
+
 import Base
 import Style
 import Paths_hmp3_ng (version)
+
+-- XXX some styles are currently unused, but planned is a CLI option to select
+
+fixedStyles :: M.Map String UIStyle
+fixedStyles = M.fromList
+    [ ("default", defaultStyle)
+    , ("dark",    defaultStyle)
+    , ("light",   lightBgStyle)
+    , ("mono",    bwStyle)
+    , ("mutt",    muttStyle)
+    ]
 
 defaultStyle :: UIStyle
 defaultStyle  = UIStyle { window     = style "default"      "default"
@@ -19,7 +32,7 @@ defaultStyle  = UIStyle { window     = style "default"      "default"
                         , blockcursor= style "black"        "red"
                         , progress   = style "cyan"         "white" }
 
--- | A style more suitable for light backgrounds (used if HMP_HAS_LIGHT_BG=true)
+-- | A style more suitable for light backgrounds
 lightBgStyle :: UIStyle
 lightBgStyle =
            defaultStyle { selected   = style "darkblue"     "default"

--- a/Core.hs
+++ b/Core.hs
@@ -589,9 +589,9 @@ loadConfig = do
                 let sty = buildStyle rsty
                 initcolours sty
                 modifyHS_ $ \st -> st { config = sty }
-                UI.resetui
     else
         pure () -- TODO in some cases show a warning
+    UI.resetui
 
 ------------------------------------------------------------------------
 -- Editing the minibuffer

--- a/Core.hs
+++ b/Core.hs
@@ -35,7 +35,6 @@ import FastIO               (FiltHandle(..), newFiltHandle)
 import Tree hiding (File, Dir)
 import qualified Tree (File,Dir)
 import qualified UI
-import Config (defaultStyle)
 
 import Text.Regex.PCRE.Light
 import {-# SOURCE #-} Keymap (keyLoop)
@@ -590,10 +589,9 @@ loadConfig = do
                 let sty = buildStyle rsty
                 initcolours sty
                 modifyHS_ $ \st -> st { config = sty }
-      else do
-        initcolours defaultStyle
-        modifyHS_ $ \st -> st { config = defaultStyle }
-    UI.resetui
+                UI.resetui
+    else
+        pure () -- TODO in some cases show a warning
 
 ------------------------------------------------------------------------
 -- Editing the minibuffer

--- a/Style.hs
+++ b/Style.hs
@@ -31,12 +31,17 @@ data UIStyle = UIStyle {
 
 ------------------------------------------------------------------------
 
--- | Colors 
-data Color
-    = RGB {-# UNPACK #-} !Word8 {-# UNPACK #-} !Word8 {-# UNPACK #-} !Word8
-    | Default
-    | Reverse
-    deriving stock (Eq,Ord)
+-- | A terminal colour: the terminal default, reverse-video, or one of the
+-- eight ANSI hues at normal or bright intensity.  (Bright is rendered with
+-- the bold attribute, which is how 8-colour terminals expose it.)
+data Color = Default | Reverse | Color !Intensity !Hue
+    deriving stock (Eq, Ord, Show)
+
+data Intensity = Normal | Bright
+    deriving stock (Eq, Ord, Show)
+
+data Hue = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
+    deriving stock (Eq, Ord, Show)
 
 -- | Foreground and background color pairs
 data Style = Style !Color !Color
@@ -50,28 +55,28 @@ data StringA
 
 ------------------------------------------------------------------------
 --
--- | Some simple colours (derivied from proxima\/src\/common\/CommonTypes.hs)
---
--- But we don't have a light blue?
+-- | Named colours for the config file and the built-in styles.  The
+-- \"dark\" name of each pair is the normal-intensity hue; the plain name
+-- is its bright variant (so @red@ is bright, @darkred@ is normal).
 --
 black, grey, darkred, red, darkgreen, green, brown, yellow          :: Color
 darkblue, blue, purple, magenta, darkcyan, cyan, white, brightwhite :: Color
-black       = RGB 0 0 0
-grey        = RGB 128 128 128
-darkred     = RGB 139 0 0
-red         = RGB 255 0 0
-darkgreen   = RGB 0 100 0
-green       = RGB 0 128 0
-brown       = RGB 165 42 42
-yellow      = RGB 255 255 0
-darkblue    = RGB 0 0 139
-blue        = RGB 0 0 255
-purple      = RGB 128 0 128
-magenta     = RGB 255 0 255
-darkcyan    = RGB 0 139 139 
-cyan        = RGB 0 255 255
-white       = RGB 165 165 165
-brightwhite = RGB 255 255 255
+black       = Color Normal Black
+grey        = Color Bright Black
+darkred     = Color Normal Red
+red         = Color Bright Red
+darkgreen   = Color Normal Green
+green       = Color Bright Green
+brown       = Color Normal Yellow
+yellow      = Color Bright Yellow
+darkblue    = Color Normal Blue
+blue        = Color Bright Blue
+purple      = Color Normal Magenta
+magenta     = Color Bright Magenta
+darkcyan    = Color Normal Cyan
+cyan        = Color Bright Cyan
+white       = Color Normal White
+brightwhite = Color Bright White
 
 defaultfg, defaultbg, reversefg, reversebg :: Color
 defaultfg   = Default
@@ -224,57 +229,39 @@ reverseA    = setReverseA   nullA
 ------------------------------------------------------------------------
 
 newtype CColor = CColor (Curses.Attr, Curses.Color)
--- 
--- | Map Style rgb rgb colours to ncurses pairs
--- TODO a generic way to turn an rgb into the nearest curses color
---
+
+-- | Map an abstract 'Style' to its ncurses foreground/background pair.
 style2curses :: Style -> (CColor, CColor)
 style2curses (Style fg bg) = (fgCursCol fg, bgCursCol bg)
 {-# INLINE style2curses #-}
 
-fgCursCol :: Color -> CColor
-fgCursCol c = case c of
-    RGB 0 0 0         -> CColor (nullA, cblack)
-    RGB 128 128 128   -> CColor (boldA, cblack)
-    RGB 139 0 0       -> CColor (nullA, cred)
-    RGB 255 0 0       -> CColor (boldA, cred)
-    RGB 0 100 0       -> CColor (nullA, cgreen)
-    RGB 0 128 0       -> CColor (boldA, cgreen)
-    RGB 165 42 42     -> CColor (nullA, cyellow)
-    RGB 255 255 0     -> CColor (boldA, cyellow)
-    RGB 0 0 139       -> CColor (nullA, cblue)
-    RGB 0 0 255       -> CColor (boldA, cblue)
-    RGB 128 0 128     -> CColor (nullA, cmagenta)
-    RGB 255 0 255     -> CColor (boldA, cmagenta)
-    RGB 0 139 139     -> CColor (nullA, ccyan)
-    RGB 0 255 255     -> CColor (boldA, ccyan)
-    RGB 165 165 165   -> CColor (nullA, cwhite)
-    RGB 255 255 255   -> CColor (boldA, cwhite)
-    Default           -> CColor (nullA, defaultColor)
-    Reverse           -> CColor (reverseA, defaultColor)
-    _                 -> CColor (nullA, cblack) -- NB
+-- | The ncurses colour for each ANSI hue.
+hueColor :: Hue -> Curses.Color
+hueColor = \case
+    Black   -> cblack
+    Red     -> cred
+    Green   -> cgreen
+    Yellow  -> cyellow
+    Blue    -> cblue
+    Magenta -> cmagenta
+    Cyan    -> ccyan
+    White   -> cwhite
 
+-- | Foreground: bright hues take the bold attribute.
+fgCursCol :: Color -> CColor
+fgCursCol = \case
+    Default        -> CColor (nullA, defaultColor)
+    Reverse        -> CColor (reverseA, defaultColor)
+    Color Bright h -> CColor (boldA, hueColor h)
+    Color Normal h -> CColor (nullA, hueColor h)
+
+-- | Background: a terminal can't embolden a background, so intensity is
+-- dropped here.
 bgCursCol :: Color -> CColor
-bgCursCol c = case c of
-    RGB 0 0 0         -> CColor (nullA, cblack)
-    RGB 128 128 128   -> CColor (nullA, cblack)
-    RGB 139 0 0       -> CColor (nullA, cred)
-    RGB 255 0 0       -> CColor (nullA, cred)
-    RGB 0 100 0       -> CColor (nullA, cgreen)
-    RGB 0 128 0       -> CColor (nullA, cgreen)
-    RGB 165 42 42     -> CColor (nullA, cyellow)
-    RGB 255 255 0     -> CColor (nullA, cyellow)
-    RGB 0 0 139       -> CColor (nullA, cblue)
-    RGB 0 0 255       -> CColor (nullA, cblue)
-    RGB 128 0 128     -> CColor (nullA, cmagenta)
-    RGB 255 0 255     -> CColor (nullA, cmagenta)
-    RGB 0 139 139     -> CColor (nullA, ccyan)
-    RGB 0 255 255     -> CColor (nullA, ccyan)
-    RGB 165 165 165   -> CColor (nullA, cwhite)
-    RGB 255 255 255   -> CColor (nullA, cwhite)
-    Default           -> CColor (nullA, defaultColor)
-    Reverse           -> CColor (reverseA, defaultColor)
-    _                 -> CColor (nullA, cwhite)    -- NB
+bgCursCol = \case
+    Default   -> CColor (nullA, defaultColor)
+    Reverse   -> CColor (reverseA, defaultColor)
+    Color _ h -> CColor (nullA, hueColor h)
 
 defaultSty :: Style
 defaultSty = Style Default Default

--- a/Style.hs
+++ b/Style.hs
@@ -59,52 +59,24 @@ data StringA
 -- \"dark\" name of each pair is the normal-intensity hue; the plain name
 -- is its bright variant (so @red@ is bright, @darkred@ is normal).
 --
-black, grey, darkred, red, darkgreen, green, brown, yellow          :: Color
-darkblue, blue, purple, magenta, darkcyan, cyan, white, brightwhite :: Color
-black       = Color Normal Black
-grey        = Color Bright Black
-darkred     = Color Normal Red
-red         = Color Bright Red
-darkgreen   = Color Normal Green
-green       = Color Bright Green
-brown       = Color Normal Yellow
-yellow      = Color Bright Yellow
-darkblue    = Color Normal Blue
-blue        = Color Bright Blue
-purple      = Color Normal Magenta
-magenta     = Color Bright Magenta
-darkcyan    = Color Normal Cyan
-cyan        = Color Bright Cyan
-white       = Color Normal White
-brightwhite = Color Bright White
-
-defaultfg, defaultbg, reversefg, reversebg :: Color
-defaultfg   = Default
-defaultbg   = Default
-reversefg   = Reverse
-reversebg   = Reverse
-
---
--- | map strings to colors
---
 stringToColor :: String -> Maybe Color
 stringToColor s = case map toLower s of
-    "black"         -> Just black
-    "grey"          -> Just grey
-    "darkred"       -> Just darkred
-    "red"           -> Just red
-    "darkgreen"     -> Just darkgreen
-    "green"         -> Just green
-    "brown"         -> Just brown
-    "yellow"        -> Just yellow
-    "darkblue"      -> Just darkblue
-    "blue"          -> Just blue
-    "purple"        -> Just purple
-    "magenta"       -> Just magenta
-    "darkcyan"      -> Just darkcyan
-    "cyan"          -> Just cyan
-    "white"         -> Just white
-    "brightwhite"   -> Just brightwhite
+    "black"         -> Just $ Color Normal Black
+    "grey"          -> Just $ Color Bright Black
+    "darkred"       -> Just $ Color Normal Red
+    "red"           -> Just $ Color Bright Red
+    "darkgreen"     -> Just $ Color Normal Green
+    "green"         -> Just $ Color Bright Green
+    "brown"         -> Just $ Color Normal Yellow
+    "yellow"        -> Just $ Color Bright Yellow
+    "darkblue"      -> Just $ Color Normal Blue
+    "blue"          -> Just $ Color Bright Blue
+    "purple"        -> Just $ Color Normal Magenta
+    "magenta"       -> Just $ Color Bright Magenta
+    "darkcyan"      -> Just $ Color Normal Cyan
+    "cyan"          -> Just $ Color Bright Cyan
+    "white"         -> Just $ Color Normal White
+    "brightwhite"   -> Just $ Color Bright White
     "default"       -> Just Default
     "reverse"       -> Just Reverse
     _               -> Nothing
@@ -141,7 +113,6 @@ initcolours sty = do
                selected sty, titlebar sty, progress sty,
                blockcursor sty, cursors sty, combined sty ]
         (Style fg bg) = progress sty    -- bonus style
-
     pairs <- initUiColors (ls ++ [Style bg bg, Style fg fg])
     writeIORef pairMap pairs
     -- set the background
@@ -247,6 +218,9 @@ bgCursCol = \case
 
 defaultSty :: Style
 defaultSty = Style Default Default
+
+style :: String -> String -> Style
+style a b = let f = fromJust . stringToColor in Style (f a) (f b)
 
 ------------------------------------------------------------------------
 --

--- a/Style.hs
+++ b/Style.hs
@@ -201,16 +201,6 @@ pairMap = unsafePerformIO $ newIORef M.empty
 defaultColor :: Curses.Color
 defaultColor = fromJust $ Curses.color "default"
 
-cblack, cred, cgreen, cyellow, cblue, cmagenta, ccyan, cwhite :: Curses.Color
-cblack     = fromJust $ Curses.color "black"
-cred       = fromJust $ Curses.color "red"
-cgreen     = fromJust $ Curses.color "green"
-cyellow    = fromJust $ Curses.color "yellow"
-cblue      = fromJust $ Curses.color "blue"
-cmagenta   = fromJust $ Curses.color "magenta"
-ccyan      = fromJust $ Curses.color "cyan"
-cwhite     = fromJust $ Curses.color "white"
-
 --
 -- Combine attribute with another attribute
 --
@@ -237,15 +227,7 @@ style2curses (Style fg bg) = (fgCursCol fg, bgCursCol bg)
 
 -- | The ncurses color for each ANSI hue.
 hueColor :: Hue -> Curses.Color
-hueColor = \case
-    Black   -> cblack
-    Red     -> cred
-    Green   -> cgreen
-    Yellow  -> cyellow
-    Blue    -> cblue
-    Magenta -> cmagenta
-    Cyan    -> ccyan
-    White   -> cwhite
+hueColor = fromJust . Curses.color . map toLower . show
 
 -- | Foreground: bright hues take the bold attribute.
 fgCursCol :: Color -> CColor
@@ -307,3 +289,4 @@ buildStyle bs = UIStyle {
     where 
         f (x,y) = Style (g x) (g y)
         g x     = fromMaybe Default $ stringToColor x
+

--- a/Style.hs
+++ b/Style.hs
@@ -31,9 +31,9 @@ data UIStyle = UIStyle {
 
 ------------------------------------------------------------------------
 
--- | A terminal colour: the terminal default, reverse-video, or one of the
+-- | A terminal color: the terminal default, reverse-video, or one of the
 -- eight ANSI hues at normal or bright intensity.  (Bright is rendered with
--- the bold attribute, which is how 8-colour terminals expose it.)
+-- the bold attribute, which is how 8-color terminals expose it.)
 data Color = Default | Reverse | Color !Intensity !Hue
     deriving stock (Eq, Ord, Show)
 
@@ -55,7 +55,7 @@ data StringA
 
 ------------------------------------------------------------------------
 --
--- | Named colours for the config file and the built-in styles.  The
+-- | Named colors for the config file and the built-in styles.  The
 -- \"dark\" name of each pair is the normal-intensity hue; the plain name
 -- is its bright variant (so @red@ is bright, @darkred@ is normal).
 --
@@ -235,7 +235,7 @@ style2curses :: Style -> (CColor, CColor)
 style2curses (Style fg bg) = (fgCursCol fg, bgCursCol bg)
 {-# INLINE style2curses #-}
 
--- | The ncurses colour for each ANSI hue.
+-- | The ncurses color for each ANSI hue.
 hueColor :: Hue -> Curses.Color
 hueColor = \case
     Black   -> cblack

--- a/UI.hs
+++ b/UI.hs
@@ -77,11 +77,7 @@ start = do
         _        -> pure () -- handled elsewhere
 
     colorify <- Curses.hasColors
-    light    <- isLightBg
-
-    let sty | colorify && light = lightBgStyle
-            | colorify          = defaultStyle
-            | otherwise         = bwStyle 
+    let sty = if colorify then defaultStyle else bwStyle
 
     initcolours sty
     Curses.keypad Curses.stdScr True    -- grab the keyboard
@@ -169,14 +165,6 @@ refresh = runDraw $ redraw <> Draw Curses.refresh
 
 refreshClock :: IO ()
 refreshClock = runDraw $ redrawJustClock <> Draw Curses.refresh
-
---
--- | Some evil to work out if the background is light, or dark. Assume dark.
---
-isLightBg :: IO Bool
-isLightBg = handle @SomeException (\_ -> pure False) do
-    e <- getEnv "HMP_HAS_LIGHT_BG"
-    pure $ map toLower e == "true"
 
 ------------------------------------------------------------------------
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -99,6 +99,7 @@ test-suite test
       CoreSpec
       FastIOSpec
       LexerSpec
+      StyleSpec
       TreeSpec
       WidthSpec
   build-depends:

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -96,6 +96,7 @@ test-suite test
   main-is: Main.hs
   hs-source-dirs: test
   other-modules:
+      ConfigSpec
       CoreSpec
       FastIOSpec
       LexerSpec

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -1,0 +1,34 @@
+module ConfigSpec (tests) where
+
+import Control.Exception
+import Data.Either (isRight)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Config (fixedStyles, defaultStyle)
+import Style (UIStyle(..), style)
+
+tests :: TestTree
+tests = testGroup "Config"
+    [ testGroup "styles"
+        [ testT "built-in styles valid" fixedStyles True
+        , testT "wrong style invalid" badT False
+        ]
+    ]
+
+-- Check WHNF evaluation doesn't throw.
+evalOk :: a -> IO Bool
+evalOk = fmap isRight . try @SomeException . evaluate
+
+testT :: Traversable t => String -> t UIStyle -> Bool -> TestTree
+testT s m b = testCase s $ (@?= b) . and =<< traverse evalOk m
+
+-- Test that test actually tests.
+badT :: [UIStyle]
+badT =
+    [ defaultStyle
+    , defaultStyle { window = style "badcolor" "default" }
+    , defaultStyle
+    ]
+

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -12,21 +12,22 @@ import Style (UIStyle(..), style)
 tests :: TestTree
 tests = testGroup "Config"
     [ testGroup "styles"
-        [ testT "built-in styles valid" fixedStyles True
-        , testT "wrong style invalid" badT False
+        [ testStyles "built-in styles valid" fixedStyles True
+        , testStyles "wrong style invalid" badStyles False
         ]
     ]
 
 -- Check WHNF evaluation doesn't throw.
+-- Suffices because UIStyle is recursively strict.
 evalOk :: a -> IO Bool
 evalOk = fmap isRight . try @SomeException . evaluate
 
-testT :: Traversable t => String -> t UIStyle -> Bool -> TestTree
-testT s m b = testCase s $ (@?= b) . and =<< traverse evalOk m
+testStyles :: Traversable t => String -> t UIStyle -> Bool -> TestTree
+testStyles s m b = testCase s $ (@?= b) . and =<< traverse evalOk m
 
 -- Test that test actually tests.
-badT :: [UIStyle]
-badT =
+badStyles :: [UIStyle]
+badStyles =
     [ defaultStyle
     , defaultStyle { window = style "badcolor" "default" }
     , defaultStyle

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Tasty
 
+import qualified ConfigSpec
 import qualified CoreSpec
 import qualified FastIOSpec
 import qualified LexerSpec
@@ -11,10 +12,12 @@ import qualified WidthSpec
 
 main :: IO ()
 main = defaultMain $ testGroup "hmp3-ng"
-    [ CoreSpec.tests
+    [ ConfigSpec.tests
+    , CoreSpec.tests
     , FastIOSpec.tests
     , LexerSpec.tests
     , StyleSpec.tests
     , TreeSpec.tests
     , WidthSpec.tests
     ]
+

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import qualified CoreSpec
 import qualified FastIOSpec
 import qualified LexerSpec
+import qualified StyleSpec
 import qualified TreeSpec
 import qualified WidthSpec
 
@@ -13,6 +14,7 @@ main = defaultMain $ testGroup "hmp3-ng"
     [ CoreSpec.tests
     , FastIOSpec.tests
     , LexerSpec.tests
+    , StyleSpec.tests
     , TreeSpec.tests
     , WidthSpec.tests
     ]

--- a/test/StyleSpec.hs
+++ b/test/StyleSpec.hs
@@ -1,0 +1,35 @@
+module StyleSpec (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Style
+
+-- Lock in the config-string -> Color mapping and, with it, the intensity
+-- assignment of each named colour (the "dark" name is normal intensity, the
+-- plain name is bright).  This guards the 8-colour table against accidental
+-- transcription errors.
+
+tests :: TestTree
+tests = testGroup "Style"
+    [ testGroup "stringToColor"
+        [ testCase "plain name is the bright hue"
+            $ stringToColor "red"        @?= Just (Color Bright Red)
+        , testCase "dark name is the normal hue"
+            $ stringToColor "darkred"    @?= Just (Color Normal Red)
+        , testCase "grey is bright black"
+            $ stringToColor "grey"       @?= Just (Color Bright Black)
+        , testCase "brightwhite is bright white"
+            $ stringToColor "brightwhite" @?= Just (Color Bright White)
+        , testCase "brown is normal yellow"
+            $ stringToColor "brown"      @?= Just (Color Normal Yellow)
+        , testCase "case-insensitive"
+            $ stringToColor "ReD"        @?= Just red
+        , testCase "default"
+            $ stringToColor "default"    @?= Just Default
+        , testCase "reverse"
+            $ stringToColor "reverse"    @?= Just Reverse
+        , testCase "unknown name"
+            $ stringToColor "chartreuse" @?= Nothing
+        ]
+    ]

--- a/test/StyleSpec.hs
+++ b/test/StyleSpec.hs
@@ -24,7 +24,7 @@ tests = testGroup "Style"
         , testCase "brown is normal yellow"
             $ stringToColor "brown"      @?= Just (Color Normal Yellow)
         , testCase "case-insensitive"
-            $ stringToColor "ReD"        @?= Just red
+            $ stringToColor "ReD"        @?= Just (Color Bright Red)
         , testCase "default"
             $ stringToColor "default"    @?= Just Default
         , testCase "reverse"
@@ -33,3 +33,4 @@ tests = testGroup "Style"
             $ stringToColor "chartreuse" @?= Nothing
         ]
     ]
+

--- a/test/StyleSpec.hs
+++ b/test/StyleSpec.hs
@@ -6,8 +6,8 @@ import Test.Tasty.HUnit
 import Style
 
 -- Lock in the config-string -> Color mapping and, with it, the intensity
--- assignment of each named colour (the "dark" name is normal intensity, the
--- plain name is bright).  This guards the 8-colour table against accidental
+-- assignment of each named color (the "dark" name is normal intensity, the
+-- plain name is bright).  This guards the 8-color table against accidental
 -- transcription errors.
 
 tests :: TestTree


### PR DESCRIPTION
Claude Code:

The Color type carried RGB triples that were never real RGB: a config string like "red" mapped to RGB 255 0 0, which two 18-line case tables then matched *exactly* back to (bold, curses-red).  The numbers had no connection to the terminal and any off-table triple silently fell through to black/white.

Replace it with what it actually is — 8 ANSI hues at normal or bright intensity, plus Default and Reverse:

    data Color = Default | Reverse | Color !Intensity !Hue
    data Intensity = Normal | Bright
    data Hue = Black | Red | ... | White

The two case tables become `fgCursCol`/`bgCursCol` over a small `hueColor` lookup (bright = bold; background drops intensity since a terminal can't embolden a background).  The named colours and the config-file string format are unchanged, so existing style.conf files keep working; the brightness assignment of each name is preserved (plain name = bright, "dark" name = normal).

StyleSpec locks in the string->Color mapping to guard the table against transcription slips.

(True/256-colour support, hinted at by the old "nearest curses color" TODO, would be a separate Color variant with capability detection; not attempted here.)