### PR TITLE
Parse the command line with optparse-applicative; add --config.

### DIFF
--- a/Config.hs
+++ b/Config.hs
@@ -60,5 +60,3 @@ package = "hmp3-ng"
 versinfo :: String
 versinfo  = package ++ " v" ++ showVersion version
 
-help :: String
-help = "- curses-based MP3 player"

--- a/Core.hs
+++ b/Core.hs
@@ -68,8 +68,7 @@ mp3Tool =
 
 ------------------------------------------------------------------------
 
--- | Command-line configuration passed in from 'Main'.  Expected to grow
--- as more options are added.
+-- | Command-line configuration.
 data Options = Options
     { optPaused     :: !Bool             -- ^ start in a paused state
     , optConfigPath :: !(Maybe FilePath) -- ^ override the style.conf location

--- a/Core.hs
+++ b/Core.hs
@@ -8,6 +8,7 @@
 -- | Main module. 
 --
 module Core (
+    Options(..),
     start,
     shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
@@ -67,8 +68,15 @@ mp3Tool =
 
 ------------------------------------------------------------------------
 
-start :: Bool -> Tree -> IO ()
-start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
+-- | Command-line configuration passed in from 'Main'.  Expected to grow
+-- as more options are added.
+data Options = Options
+    { optPaused     :: !Bool             -- ^ start in a paused state
+    , optConfigPath :: !(Maybe FilePath) -- ^ override the style.conf location
+    }
+
+start :: Options -> Tree -> IO ()
+start opts (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     c <- UI.start -- initialise curses
 
@@ -94,12 +102,13 @@ start playNow (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
         , mode         = mode
         , boottime     = now
         , config       = c
+        , configPath   = optConfigPath opts
         , threads      }
 
     loadConfig
 
     if mode == Random then runPlayOp playRandomOp else playCur
-    when (not playNow) pause
+    when (optPaused opts) pause
 
     run         -- won't restart if this fails!
 
@@ -573,7 +582,7 @@ getConfPath = getXdgDirectory XdgConfig $ "hmp3" </> "style.conf"
 
 loadConfig :: IO ()
 loadConfig = do
-    f <- getConfPath
+    f <- maybe getConfPath pure =<< getsHS configPath
     b <- doesFileExist f
     if b then do
         str' <- readFile f

--- a/State.hs
+++ b/State.hs
@@ -55,6 +55,7 @@ data HState = HState {
        ,doNotResuscitate :: !Bool                -- should we just let mpg123 die?
        ,playHist        :: !(Seq (TimeSpec, Int)) -- limited history of songs played
        ,config          :: !UIStyle             -- config values
+       ,configPath      :: !(Maybe FilePath)     -- style.conf override (CLI)
 
        ,modified        :: !(MVar ())           -- Set when redrawable components of 
                                                 -- the state are modified. The ui
@@ -101,6 +102,7 @@ newEmptyHS = do
        ,randomGen
        ,playHist     = mempty
        ,config       = Config.defaultStyle
+       ,configPath   = Nothing
        ,boottime     = 0
        ,status       = Stopped
        ,mode         = minBound

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,15 +7,17 @@ module Main where
 
 import Base
 
-import Core     (start, shutdown)
-import Config   (help, versinfo)
-import Tree     (Tree, buildTree, isEmpty)
+import Core     (start, shutdown, Options(..))
+import qualified Config
+import Tree     (buildTree, isEmpty)
 
 import System.IO            (hPrint, stderr)
 import System.Posix.Signals (installHandler, sigTERM, sigPIPE, sigINT, sigHUP
-                            ,sigALRM, sigABRT, Handler(Ignore, Default, Catch))
+                            ,sigALRM, sigABRT, Handler(Ignore, Catch))
 
 import qualified Data.ByteString.UTF8 as UTF8
+
+import Options.Applicative
 
 -- ---------------------------------------------------------------------
 -- | Set up the signal handlers
@@ -41,60 +43,38 @@ initSignals = do
             catch (shutdown Nothing) (\ (f :: SomeException) -> hPrint stderr f)
             exitWith (ExitFailure 1) )) Nothing
 
--- XXX this function is not used
-releaseSignals :: IO ()
-releaseSignals =
-    for_ [sigINT, sigPIPE, sigHUP, sigABRT, sigTERM]
-        \sig -> installHandler sig Default Nothing
+------------------------------------------------------------------------
+-- | Command-line parsing.
+
+-- | The options together with the file/directory arguments.
+invocation :: Parser (Options, [ByteString])
+invocation = (,) <$> opts <*> files
+  where
+    opts = Options
+        <$> switch
+            (long "paused" <> short 'P'
+                <> help "Start in a paused state")
+        <*> optional (strOption
+            (long "config" <> short 'c' <> metavar "FILE"
+                <> help "Read this config file instead of the XDG default"))
+    files = some $ argument (UTF8.fromString <$> str) (metavar "FILE|DIR...")
+
+parserInfo :: ParserInfo (Options, [ByteString])
+parserInfo = info (invocation <**> versionOpt <**> helper) $
+       fullDesc
+    <> header Config.versinfo
+    <> progDesc "Play the given MP3 files and directories in a curses interface."
+  where
+    versionOpt = infoOption (unwords [Config.versinfo, Config.help])
+        (long "version" <> short 'V' <> help "Show version information")
 
 ------------------------------------------------------------------------
--- | Argument parsing.
 
--- usage string.
-usage :: [String]
-usage = ["Usage: hmp3 [-VhP] [FILE|DIR ...]"
-        ,"-V  --version  Show version information"
-        ,"-h  --help     Show this help"
-        ,"-P  --paused   Start in a paused state"
-        ]
-
--- | Parse the args
-doArgs :: [ByteString] -> IO (Bool, Tree)
-doArgs = loopArgs True where
-
-    verLine = putStrLn $ unwords [versinfo, help]
-    showUsage = traverse_ putStrLn usage
-
-    loopArgs _ [] = do
-        putStrLn "Specify at least one file or directory."
-        showUsage
-        exitFailure
-
-    loopArgs _ (s:xs)
-        | s == "-V" || s == "--version"
-        = verLine *> exitSuccess
-        | s == "-h" || s == "--help"
-        = verLine *> showUsage *> exitSuccess
-        | s == "-P" || s == "--paused"
-        = loopArgs False xs
-
-    loopArgs playNow xs = do
-        tree <- buildTree xs
-        if isEmpty tree
-            then putStrLn "Error: No music files found." *> exitFailure
-            else pure (playNow, tree)
-
--- ---------------------------------------------------------------------
--- | Static main. This is the front end to the statically linked
--- application, and the real front end, in a sense. 'dynamic_main' calls
--- this after setting preferences passed from the boot loader.
---
--- Initialise the ui getting an initial editor state, set signal
--- handlers, then jump to ui event loop with the state.
---
 main :: IO ()
 main = do
-    (playNow, files) <- doArgs . map UTF8.fromString =<< getArgs
+    (opts, args) <- execParser parserInfo
     initSignals
-    start playNow files -- never returns
-
+    tree <- buildTree args
+    if isEmpty tree
+        then putStrLn "Error: No music files found." *> exitFailure
+        else start opts tree -- never returns

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import Tree     (buildTree, isEmpty)
 
 import System.IO            (hPrint, stderr)
 import System.Posix.Signals (installHandler, sigTERM, sigPIPE, sigINT, sigHUP
-                            ,sigALRM, sigABRT, Handler(Ignore, Catch))
+                            ,sigALRM, sigABRT, Handler(Ignore, Default, Catch))
 
 import qualified Data.ByteString.UTF8 as UTF8
 
@@ -42,6 +42,12 @@ initSignals = do
         installHandler sig (Catch (do
             catch (shutdown Nothing) (\ (f :: SomeException) -> hPrint stderr f)
             exitWith (ExitFailure 1) )) Nothing
+
+-- XXX this function is not used
+releaseSignals :: IO ()
+releaseSignals =
+    for_ [sigINT, sigPIPE, sigHUP, sigABRT, sigTERM]
+        \sig -> installHandler sig Default Nothing
 
 ------------------------------------------------------------------------
 -- | Command-line parsing.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -58,10 +58,9 @@ invocation = (,) <$> opts <*> files
   where
     opts = Options
         <$> switch
-            (long "paused" <> short 'P'
-                <> help "Start in a paused state")
-        <*> optional (strOption
-            (long "config" <> short 'c' <> metavar "FILE"
+            (long "paused" <> short 'P' <> help "Start in a paused state")
+        <*> optional (strOption -- temporarily internal since feature needs work
+            (long "config" <> short 'c' <> metavar "FILE" <> internal
                 <> help "Read this config file instead of the XDG default"))
     files = some $ argument (UTF8.fromString <$> str) (metavar "FILE|DIR...")
 
@@ -69,18 +68,19 @@ parserInfo :: ParserInfo (Options, [ByteString])
 parserInfo = info (invocation <**> versionOpt <**> helper) $
        fullDesc
     <> header Config.versinfo
-    <> progDesc "Play the given MP3 files and directories in a curses interface."
+    <> progDesc "Play mp3 files in a curses interface."
   where
-    versionOpt = infoOption (unwords [Config.versinfo, Config.help])
-        (long "version" <> short 'V' <> help "Show version information")
+    versionOpt = infoOption Config.versinfo
+        (hidden <> long "version" <> short 'V' <> help "Show version information")
 
 ------------------------------------------------------------------------
 
 main :: IO ()
 main = do
-    (opts, args) <- execParser parserInfo
+    (opts, args) <- customExecParser (prefs showHelpOnEmpty) parserInfo
     initSignals
     tree <- buildTree args
     if isEmpty tree
         then putStrLn "Error: No music files found." *> exitFailure
         else start opts tree -- never returns
+

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -87,6 +87,7 @@ executable hmp3
     , base
     , bytestring
     , hmp3-ng
+    , optparse-applicative
     , unix
     , utf8-string
 


### PR DESCRIPTION
Claude Code:

Replaces the hand-rolled argument loop in Main with an optparse-applicative parser, and gives `start` a record argument in place of the bare playNow boolean:

    data Options = Options
        { optPaused     :: !Bool
        , optConfigPath :: !(Maybe FilePath) }

Main builds Options (plus the file/dir args) from the CLI and hands it to `start`; the record is the place future options will go.  `--paused` /`-P` and the version/help flags behave as before; positional args are still UTF-8-encoded to RawFilePath exactly as the old code did.

New: `--config`/`-c FILE` overrides the style.conf location (#61).  The path is stored in HState and consulted by `loadConfig`, so the `l` hot-reload honours it too.

The dead `releaseSignals` (long marked unused) is dropped.

Me:

`releaseSignals` is restored as it is to be used; see #89.

The config file option is marked "internal" (not exposed to users) because there are more issues to deal with.  For one, it needs to report "file not found" somehow; for another, `loadConfig` was found to have a bug.  I don't want these issues blocking the other code work, so hiding the feature for now.

Other adjustments are made.