### PR TITLE
Release signal traps after signal shutdown attempt.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -253,15 +253,11 @@ shutdown ms = do
     discardErrors writeState
     mpid <- getsHS mpgPid
     flip (maybe $ pure ()) mpid \pid -> do
-        sendMpg Quit               -- ask politely
+        discardErrors $ sendMpg Quit
         void $ waitForProcess pid
-
-    `finally`
-
-    do  isXterm <- getsHS xterm
-        UI.end isXterm
-        when (isJust ms) $ hPutStrLn stderr (fromJust ms) >> hFlush stderr
-        exitImmediately ExitSuccess
+    UI.end =<< getsHS xterm
+    flip (maybe $ pure ()) ms \s -> hPutStrLn stderr s *> hFlush stderr
+    exitImmediately ExitSuccess
 
 ------------------------------------------------------------------------
 -- 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,32 +20,25 @@ import qualified Data.ByteString.UTF8 as UTF8
 -- ---------------------------------------------------------------------
 -- | Set up the signal handlers
 
---
--- Notes on setStoppedChildFlag:
---      If this bit is set when installing a catching function for the SIGCHLD
---      signal, the SIGCHLD signal will be generated only when a child process
---      exits, not when a child process stops.
---
--- setStoppedChildFlag True
---
 initSignals :: IO ()
 initSignals = do
-
     -- ignore
     for_ [sigPIPE, sigALRM] \sig ->
         installHandler sig Ignore Nothing
-
     -- and exit if we get the following
     for_ [sigINT, sigHUP, sigABRT, sigTERM] \sig ->
-        installHandler sig (Catch (do
-            catch (shutdown Nothing) (\ (f :: SomeException) -> hPrint stderr f)
-            exitWith (ExitFailure 1) )) Nothing
+        installHandler sig (Catch exitHandler) Nothing
 
--- XXX this function is not used
+exitHandler :: IO ()
+exitHandler = do
+    releaseSignals  -- in case shutdown itself gets stuck
+    catch @SomeException (shutdown Nothing) (hPrint stderr)
+    exitWith $ ExitFailure 1
+
 releaseSignals :: IO ()
 releaseSignals =
-    for_ [sigINT, sigPIPE, sigHUP, sigABRT, sigTERM]
-        \sig -> installHandler sig Default Nothing
+    for_ [sigINT, sigPIPE, sigHUP, sigABRT, sigTERM] \sig ->
+        installHandler sig Default Nothing
 
 ------------------------------------------------------------------------
 -- | Argument parsing.


### PR DESCRIPTION
This releases signal interceptions after a signal that would kill is received.  This is a common pattern, e.g., a second Control-C passing through if exit fails after the first is trapped.  This has arisen often for me in practice during testing due to the accidental creation of deadlocks, where I would have to SIGKILL.

I also took the `finally` out of `shutdown`.  I'm not seeing how it would help, particularly since I've added another `discardErrors`.