### PR TITLE
Rework modal state and rendering.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -52,3 +52,6 @@ sequenceWhile _ [] = pure []
 sequenceWhile p (m:ms) = m >>= \a ->
     if p a then (a:) <$> sequenceWhile p ms else pure []
 
+whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
+whenJust = flip $ maybe $ pure ()
+

--- a/Base.hs
+++ b/Base.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
--- Copyright (c) 2020-2025 Galen Huntington
+-- Copyright (c) 2020-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
 module Base (module Prelude, module X, module Base) where

--- a/Core.hs
+++ b/Core.hs
@@ -259,11 +259,11 @@ shutdown ms = do
     silentlyModifyHS $ \st -> st { doNotResuscitate = True }
     discardErrors writeState
     mpid <- getsHS mpgPid
-    flip (maybe $ pure ()) mpid \pid -> do
+    whenJust mpid \pid -> do
         discardErrors $ sendMpg Quit
         void $ waitForProcess pid
     UI.end =<< getsHS xterm
-    flip (maybe $ pure ()) ms \s -> hPutStrLn stderr s *> hFlush stderr
+    whenJust ms \s -> hPutStrLn stderr s *> hFlush stderr
     exitImmediately ExitSuccess
 
 ------------------------------------------------------------------------

--- a/Core.hs
+++ b/Core.hs
@@ -514,7 +514,7 @@ genericJumpToMatch re sw k sel = do
 mapModal :: (Maybe Modal -> Maybe Modal) -> IO ()
 mapModal f = modifyHS_ $ \st -> st { modal = f $ modal st }
 
--- | Close down open modal (if any).
+-- | Close any open modal.
 closeModal :: IO ()
 closeModal = mapModal $ const Nothing
 
@@ -526,7 +526,7 @@ openModal m = mapModal $ const $ Just m
 toggleFocus :: IO ()
 toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
 
--- | Show history.  Also, return history as value.
+-- | Show history.
 showHist :: IO ()
 showHist = do
     now <- getMonoTime

--- a/Core.hs
+++ b/Core.hs
@@ -527,14 +527,14 @@ toggleFocus :: IO ()
 toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
 
 -- | Show history.  Also, return history as value.
-showHist :: IO HistDisplay
+showHist :: IO ()
 showHist = do
     now <- getMonoTime
-    modifyHS \st ->
-        let hist = [
-                (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
+    modifyHS_ \st -> st {
+        modal = Just $ HistModal [
+            (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
                 | (tm, ix) <- toList $ playHist st ]
-        in (st { modal = Just $ HistModal hist }, hist)
+        }
 
 -- | Toggle the mode flag
 nextMode :: IO ()

--- a/Core.hs
+++ b/Core.hs
@@ -12,17 +12,16 @@ module Core (
     start,
     shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
-    forcePause, putmsg, clrmsg, toggleHelp, play, playCur,
+    forcePause, putmsg, clrmsg, play, playCur,
     jumpToPlaying, jump, jumpRel,
     upPage, downPage,
     seekStart,
     blacklist,
-    showHist, hideHist,
+    mapModal, openModal, closeModal, showHist,
     jumpToMatchDir, jumpToMatchFile,
     toggleFocus, jumpToNextDir, jumpToPrevDir,
     loadConfig,
     discardErrors,
-    toggleExit,
     showTimeDiff_,
 ) where
 
@@ -511,37 +510,36 @@ genericJumpToMatch re sw k sel = do
 
 ------------------------------------------------------------------------
 
--- | Show/hide the help window
-toggleHelp :: IO ()
-toggleHelp = modifyHS_ $ \st -> st { helpVisible = not (helpVisible st) }
+-- | General modal map function, to handle toggling, etc.
+mapModal :: (Maybe Modal -> Maybe Modal) -> IO ()
+mapModal f = modifyHS_ $ \st -> st { modal = f $ modal st }
+
+-- | Close down open modal (if any).
+closeModal :: IO ()
+closeModal = mapModal $ const Nothing
+
+-- | Open specified modal.
+openModal :: Modal -> IO ()
+openModal m = mapModal $ const $ Just m
 
 -- | Focus the minibuffer
 toggleFocus :: IO ()
 toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
 
--- | Show/hide the confirm exit modal
-toggleExit :: IO ()
-toggleExit = modifyHS_ $ \st -> st { exitVisible = not (exitVisible st) }
-
--- | History on or off
-hideHist :: IO ()
-hideHist = modifyHS_ $ \st -> st { histVisible = Nothing }
-
-showHist :: IO ()
+-- | Show history.  Also, return history as value.
+showHist :: IO HistDisplay
 showHist = do
     now <- getMonoTime
-    modifyHS_ $ \st -> st {
-        helpVisible = False,
-        histVisible = Just $ do
-            (tm, ix) <- toList $ playHist st
-            pure (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
-        }
+    modifyHS \st ->
+        let hist = [
+                (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
+                | (tm, ix) <- toList $ playHist st ]
+        in (st { modal = Just $ HistModal hist }, hist)
 
 -- | Toggle the mode flag
 nextMode :: IO ()
-nextMode = modifyHS_ $ \st -> st { mode = next (mode st) }
-    where
-        next v = if v == maxBound then minBound else succ v
+nextMode = modifyHS_ $ \st -> st { mode = next (mode st) } where
+    next v = if v == maxBound then minBound else succ v
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -17,7 +17,7 @@ module Core (
     upPage, downPage,
     seekStart,
     blacklist,
-    mapModal, openModal, closeModal, showHist,
+    setsModal, closeModal, showHist,
     jumpToMatchDir, jumpToMatchFile,
     toggleFocus, jumpToNextDir, jumpToPrevDir,
     loadConfig,
@@ -510,31 +510,25 @@ genericJumpToMatch re sw k sel = do
 
 ------------------------------------------------------------------------
 
--- | General modal map function, to handle toggling, etc.
-mapModal :: (Maybe Modal -> Maybe Modal) -> IO ()
-mapModal f = modifyHS_ $ \st -> st { modal = f $ modal st }
+-- | General modal setting.
+setsModal :: (HState -> Maybe Modal) -> IO ()
+setsModal f = modifyHS_ $ \st -> st { modal = f st }
 
 -- | Close any open modal.
 closeModal :: IO ()
-closeModal = mapModal $ const Nothing
-
--- | Open specified modal.
-openModal :: Modal -> IO ()
-openModal m = mapModal $ const $ Just m
-
--- | Focus the minibuffer
-toggleFocus :: IO ()
-toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
+closeModal = setsModal $ const Nothing
 
 -- | Show history.
 showHist :: IO ()
 showHist = do
     now <- getMonoTime
-    modifyHS_ \st -> st {
-        modal = Just $ HistModal [
-            (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
-                | (tm, ix) <- toList $ playHist st ]
-        }
+    setsModal \st -> Just $ HistModal [
+        (showTimeDiff_ True tm now, (ix, fbase $ music st ! ix))
+            | (tm, ix) <- toList $ playHist st ]
+
+-- | Focus the minibuffer
+toggleFocus :: IO ()
+toggleFocus = modifyHS_ $ \st -> st { miniFocused = not (miniFocused st) }
 
 -- | Toggle the mode flag
 nextMode :: IO ()

--- a/Core.hs
+++ b/Core.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 
 -- Copyright (c) 2005-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2008, 2019-2026 Galen Huntington
@@ -43,6 +43,7 @@ import qualified Data.ByteString.Char8 as P
 import qualified Data.Sequence as Seq
 
 import Data.Array               ((!), bounds, Array)
+import Data.Proxy
 import Data.Tuple               (swap)
 import Control.Monad.State.Strict
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
@@ -124,12 +125,12 @@ runForever fn = catch (forever fn) handler where
 -- I don't know why these are ignored, but preserving old logic.
 -- For profiling, make sure to return True for anything:
 exitTime :: SomeException -> Bool
-exitTime e | is @IOException e = False -- ignore
-           | is @ErrorCall e   = False -- ignore
+exitTime e | is @IOException Proxy e = False -- ignore
+           | is @ErrorCall Proxy e   = False -- ignore
            -- "user errors" were caught before, but are no longer a thing
-           | otherwise         = True
-    where is :: forall e. Exception e => SomeException -> Bool
-          is = isJust . fromException @e
+           | otherwise               = True
+    where is :: forall e. Exception e => Proxy e -> SomeException -> Bool
+          is _ = isJust . fromException @e
 
 ------------------------------------------------------------------------
 

--- a/FastIO.hs
+++ b/FastIO.hs
@@ -1,5 +1,5 @@
 -- Copyright (c) 2005-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
--- Copyright (c) 2019-2021, 2025 Galen Huntington
+-- Copyright (c) 2019-2021, 2025-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
 -- | ByteString versions of some common IO functions

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -218,6 +218,10 @@ keyTable =
 keyMap :: M.Map Char (IO ())
 keyMap = M.fromList [ (c, a) | (_, cs, a) <- keyTable, c <- cs ]
 
+keysHelp :: [([Char], String)]
+keysHelp = [ (keys, desc) | (desc, keys, _) <- keyTable ]
+
 toggleHelp :: IO ()
-toggleHelp = mapModal \m -> if isNothing m then Just HelpModal else Nothing
+toggleHelp = mapModal \m ->
+    if isNothing m then Just $ HelpModal keysHelp else Nothing
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -18,7 +18,7 @@ import Base hiding ((!?))
 
 import Core
 import Config       (package)
-import State        (getsHS, touchHS, modifyHS_, HState(histVisible, searchHist))
+import State        (getsHS, touchHS, modifyHS_, Modal(..), HistDisplay, HState(..))
 import Style        (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
 
@@ -48,11 +48,14 @@ keyLoop = go mainMode where
 
 mainMode :: KeyMap
 mainMode = KeyMap dispatch where
-    dispatch 'q'  = forcePause *> toggleExit *> touchHS $> confirmQuitMode
+    dispatch 'q'  = forcePause *> openModal ExitModal $> confirmQuitMode
     dispatch c
         | c `elem` ['/', '?', '\\', '|']
                                = enterSearch c
-        | c `elem` ['H', ';']  = showHist *> touchHS $> historyMode
+        | c `elem` ['H', ';']  = do
+            h <- showHist
+            touchHS
+            pure $ historyMode h
         | c >= '1' && c <= '9' =
             jumpRel (0.1 * fromIntegral (fromEnum c - 48)) $> mainMode
         | True                 = sequence_ (M.lookup c keyMap) $> mainMode
@@ -125,12 +128,10 @@ zipDown z                       = z
 ------------------------------------------------------------------------
 -- Song-history popup
 
-historyMode :: KeyMap
-historyMode = KeyMap \c -> do
-    for_ (M.lookup c historyKeys) \k -> do
-        phm <- getsHS histVisible
-        for_ (phm >>= (!? k)) (jump . fst . snd)
-    hideHist
+historyMode :: HistDisplay -> KeyMap
+historyMode hist = KeyMap \c -> do
+    for_ (M.lookup c historyKeys >>= (hist !?)) (jump . fst . snd)
+    closeModal
     touchHS
     pure mainMode
   where
@@ -147,7 +148,7 @@ historyMode = KeyMap \c -> do
 confirmQuitMode :: KeyMap
 confirmQuitMode = KeyMap \case
     'y' -> shutdown Nothing $> undefined -- shutdown never returns
-    _   -> toggleExit *> touchHS $> mainMode
+    _   -> closeModal *> touchHS $> mainMode
 
 
 ------------------------------------------------------------------------
@@ -216,4 +217,7 @@ keyTable =
 -- Compiled dispatch table for normal-mode single-key commands.
 keyMap :: M.Map Char (IO ())
 keyMap = M.fromList [ (c, a) | (_, cs, a) <- keyTable, c <- cs ]
+
+toggleHelp :: IO ()
+toggleHelp = mapModal \m -> if isNothing m then Just HelpModal else Nothing
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -49,7 +49,8 @@ keyLoop = go mainMode where
 
 mainMode :: KeyMap
 mainMode = KeyMap dispatch where
-    dispatch 'q'  = forcePause *> openModal ExitModal $> confirmQuitMode
+    dispatch 'q'  =
+        forcePause *> setsModal (const $ Just ExitModal) $> confirmQuitMode
     dispatch c
         | c `elem` ['/', '?', '\\', '|']
                                = enterSearch c
@@ -221,6 +222,6 @@ keysHelp :: [([Char], ByteString)]
 keysHelp = [ (keys, desc) | (desc, keys, _) <- keyTable ]
 
 toggleHelp :: IO ()
-toggleHelp = mapModal \m ->
-    if isNothing m then Just $ HelpModal keysHelp else Nothing
+toggleHelp = setsModal \st ->
+    if isNothing $ modal st then Just $ HelpModal keysHelp else Nothing
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -25,6 +25,7 @@ import qualified UI (getKey, resetui)
 import UI.HSCurses.Curses (Key(..), decodeKey)
 
 import qualified Data.ByteString.Char8 as P
+import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Map.Strict as M
 
 
@@ -178,7 +179,7 @@ delete' = ['\BS', '\DEL', unkey KeyBackspace]
 ------------------------------------------------------------------------
 -- The keymap with help descriptions and actions.
 
-keyTable :: [(String, [Char], IO ())]
+keyTable :: [(ByteString, [Char], IO ())]
 keyTable =
     [ ("Move up",                                 ['k',unkey KeyUp],    upOne)
     , ("Move down",                               ['j',unkey KeyDown],  downOne)
@@ -210,7 +211,7 @@ keyTable =
     , ("Search backwards for file",               ['?'],                placeholder)
     , ("Search for directory matching regex",     ['\\'],               placeholder)
     , ("Search backwards for directory",          ['|'],                placeholder)
-    , ("Quit " ++ package,                        ['q'],                placeholder)
+    , ("Quit " <> UTF8.fromString package,        ['q'],                placeholder)
     ]
   where placeholder = pure () -- handled separately
 
@@ -218,7 +219,7 @@ keyTable =
 keyMap :: M.Map Char (IO ())
 keyMap = M.fromList [ (c, a) | (_, cs, a) <- keyTable, c <- cs ]
 
-keysHelp :: [([Char], String)]
+keysHelp :: [([Char], ByteString)]
 keysHelp = [ (keys, desc) | (desc, keys, _) <- keyTable ]
 
 toggleHelp :: IO ()

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -18,7 +18,7 @@ import Base hiding ((!?))
 
 import Core
 import Config       (package)
-import State        (getsHS, touchHS, modifyHS_, Modal(..), HistDisplay, HState(..))
+import State        (getsHS, touchHS, modifyHS_, Modal(..), HState(..))
 import Style        (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
 
@@ -53,10 +53,7 @@ mainMode = KeyMap dispatch where
     dispatch c
         | c `elem` ['/', '?', '\\', '|']
                                = enterSearch c
-        | c `elem` ['H', ';']  = do
-            h <- showHist
-            touchHS
-            pure $ historyMode h
+        | c `elem` ['H', ';']  = showHist *> touchHS $> historyMode
         | c >= '1' && c <= '9' =
             jumpRel (0.1 * fromIntegral (fromEnum c - 48)) $> mainMode
         | True                 = sequence_ (M.lookup c keyMap) $> mainMode
@@ -129,8 +126,9 @@ zipDown z                       = z
 ------------------------------------------------------------------------
 -- Song-history popup
 
-historyMode :: HistDisplay -> KeyMap
-historyMode hist = KeyMap \c -> do
+historyMode :: KeyMap
+historyMode = KeyMap \c -> do
+    hist <- getsHS $ (\case Just (HistModal h) -> h; _ -> []) . modal
     for_ (M.lookup c historyKeys >>= (hist !?)) (jump . fst . snd)
     closeModal
     touchHS

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -17,9 +17,9 @@ module Keymap (keyLoop, keyTable, unkey, charToKey) where
 import Base hiding ((!?))
 
 import Core
-import Config       (package)
-import State        (getsHS, touchHS, modifyHS_, Modal(..), HState(..))
-import Style        (defaultSty, StringA(Fast))
+import Config (package)
+import State (getsHS, touchHS, modifyHS_, KeysHelp, Modal(..), HState(..))
+import Style (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
 
 import UI.HSCurses.Curses (Key(..), decodeKey)
@@ -218,7 +218,7 @@ keyTable =
 keyMap :: M.Map Char (IO ())
 keyMap = M.fromList [ (c, a) | (_, cs, a) <- keyTable, c <- cs ]
 
-keysHelp :: [([Char], ByteString)]
+keysHelp :: [KeysHelp]
 keysHelp = [ (keys, desc) | (desc, keys, _) <- keyTable ]
 
 toggleHelp :: IO ()

--- a/Keymap.hs-boot
+++ b/Keymap.hs-boot
@@ -4,7 +4,6 @@ import UI.HSCurses.Curses (Key)
 
 keyLoop :: IO ()
 
-keyTable   :: [(String, [Char], IO ())]
 unkey      :: Key -> Char
 charToKey  :: Char -> Key
 

--- a/State.hs
+++ b/State.hs
@@ -61,7 +61,7 @@ data HState = HState {
        ,drawLock        :: !(MVar ())           -- simple semaphore for display
     }
 
--- Each is (timestamp, (song-index, song-name)).
+-- Each is (timestamp-string, (song-index, song-name)).
 type HistDisplay = [(ByteString, (Int, ByteString))]
 
 -- (list-of-keys, description)

--- a/State.hs
+++ b/State.hs
@@ -64,7 +64,10 @@ data HState = HState {
 -- Each is (timestamp, (song-index, song-name)).
 type HistDisplay = [(ByteString, (Int, ByteString))]
 
-data Modal = HelpModal | ExitModal | HistModal !HistDisplay
+-- Each is (list-of-keys, description)
+type KeysHelp = ([Char], String)
+
+data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
 
 ------------------------------------------------------------------------
 --

--- a/State.hs
+++ b/State.hs
@@ -64,7 +64,7 @@ data HState = HState {
 -- Each is (timestamp, (song-index, song-name)).
 type HistDisplay = [(ByteString, (Int, ByteString))]
 
--- Each is (list-of-keys, description)
+-- (list-of-keys, description)
 type KeysHelp = ([Char], ByteString)
 
 data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay

--- a/State.hs
+++ b/State.hs
@@ -43,7 +43,7 @@ data HState = HState {
        ,status          :: !Status
        ,minibuffer      :: !StringA              -- contents of minibuffer
        ,helpVisible     :: !Bool                 -- is the help window shown?
-       ,histVisible     :: !(Maybe [(ByteString, (Int, ByteString))]) -- history pop-up if shown
+       ,histVisible     :: !(Maybe HistDisplay)  -- history pop-up if shown
        ,exitVisible     :: !Bool                 -- confirm exit modal shown
        ,miniFocused     :: !Bool                 -- is the mini buffer focused?
        ,mode            :: !Mode
@@ -62,6 +62,11 @@ data HState = HState {
                                                 -- refresh thread waits on this.
        ,drawLock        :: !(MVar ())           -- simple semaphore for display
     }
+
+-- Each is (timestamp, (song-index, song-name)).
+type HistDisplay = [(ByteString, (Int, ByteString))]
+
+data Modal = HelpModal | ExitModal | HistModal !HistDisplay
 
 ------------------------------------------------------------------------
 --

--- a/State.hs
+++ b/State.hs
@@ -42,9 +42,7 @@ data HState = HState {
        ,info            :: !(Maybe Info)         -- mp3 info
        ,status          :: !Status
        ,minibuffer      :: !StringA              -- contents of minibuffer
-       ,helpVisible     :: !Bool                 -- is the help window shown?
-       ,histVisible     :: !(Maybe HistDisplay)  -- history pop-up if shown
-       ,exitVisible     :: !Bool                 -- confirm exit modal shown
+       ,modal           :: !(Maybe Modal)        -- modal visible
        ,miniFocused     :: !Bool                 -- is the mini buffer focused?
        ,mode            :: !Mode
        ,uptime          :: !ByteString
@@ -97,9 +95,7 @@ newEmptyHS = do
        ,searchHist   = []
 
        ,clockUpdate      = False
-       ,helpVisible      = False
-       ,histVisible      = Nothing
-       ,exitVisible      = False
+       ,modal            = Nothing
        ,miniFocused      = False
        ,xterm            = False
        ,doNotResuscitate = False    -- mpg123 should be restarted

--- a/State.hs
+++ b/State.hs
@@ -65,7 +65,7 @@ data HState = HState {
 type HistDisplay = [(ByteString, (Int, ByteString))]
 
 -- Each is (list-of-keys, description)
-type KeysHelp = ([Char], String)
+type KeysHelp = ([Char], ByteString)
 
 data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
 

--- a/UI.hs
+++ b/UI.hs
@@ -225,8 +225,8 @@ commonModalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
 helpModal :: [KeysHelp] -> ModalMaker
 helpModal help swd = (wd, map showLine help) where
     wd = commonModalWidth swd
-    showLine :: ([Char], String) -> ByteString
-    showLine (cs, ps) = toWidth clen cmds <> u ps where
+    showLine :: ([Char], ByteString) -> ByteString
+    showLine (cs, ps) = toWidth clen cmds <> ps where
         clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
         cmds = P.unwords ("" : map pprIt cs)
         pprIt c = case c of

--- a/UI.hs
+++ b/UI.hs
@@ -248,7 +248,7 @@ helpModal swd = (wd, [f cs h | (h, cs, _) <- keyTable ]) where
 
 ------------------------------------------------------------------------
 
-histModal :: [(ByteString, (Int, ByteString))] -> ModalMaker
+histModal :: HistDisplay -> ModalMaker
 histModal hist swd = do
     let wd = commonModalWidth swd
         mtlen = maximum $ map (displayWidth . fst) hist

--- a/UI.hs
+++ b/UI.hs
@@ -499,9 +499,10 @@ renderModal st (Size h w) mkr = do
 renderModals :: HState -> Size -> IO ()
 renderModals st sz = do
     let render = renderModal st sz
-    when (helpVisible st) $ render helpModal
-    whenJust (histVisible st) $ render . histModal
-    when (exitVisible st) $ render exitModal
+    whenJust (modal st) $ render . \case
+        HelpModal   -> helpModal
+        HistModal h -> histModal h
+        ExitModal   -> exitModal
 
 ------------------------------------------------------------------------
 --

--- a/UI.hs
+++ b/UI.hs
@@ -184,7 +184,7 @@ data HistModal
 data ExitModal
 class ModalElement a where
     -- takes window width, state; returns (width, list of lines)
-    drawModal :: Int -> HState -> Maybe (Int, [ByteString])
+    drawModal :: Int -> HState -> (Int, [ByteString])
 
 ------------------------------------------------------------------------
 
@@ -221,17 +221,14 @@ pInfo DD{drawState=st} = case info st of
     Nothing -> "(empty)"
     Just i  -> userinfo i
 
-modalWidth :: Int -> Int
-modalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
+commonModalWidth :: Int -> Int
+commonModalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
 
 ------------------------------------------------------------------------
 
 instance ModalElement HelpModal where
-    drawModal swd st = do
-        guard $ helpVisible st
-        pure (wd, [f cs h | (h, cs, _) <- keyTable ])
-      where
-        wd = modalWidth swd
+    drawModal swd _ = (wd, [f cs h | (h, cs, _) <- keyTable ]) where
+        wd = commonModalWidth swd
         f :: [Char] -> String -> ByteString
         f cs ps = toWidth clen cmds <> u ps where
             clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
@@ -256,8 +253,9 @@ instance ModalElement HelpModal where
 ------------------------------------------------------------------------
 
 instance ModalElement HistModal where
-    drawModal swd st = flip fmap (histVisible st) \hist -> do
-        let wd = modalWidth swd
+    drawModal swd st = do
+        let wd = commonModalWidth swd
+            hist = fromJust $ histVisible st
             mtlen = maximum $ map (displayWidth . fst) hist
             tlen = min (mtlen + 1) $ wd `div` 3
         (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
@@ -267,11 +265,10 @@ instance ModalElement HistModal where
 ------------------------------------------------------------------------
 
 instance ModalElement ExitModal where
-    drawModal swd st = do
-        guard $ exitVisible st
-        let wd = modalWidth swd `min` 19
+    drawModal swd _ = do
+        let wd = commonModalWidth swd `min` 19
             padl = P.replicate ((wd - 9) `div` 2) ' '
-        pure (wd, ["", padl <> "Exit (y)?", ""])
+        (wd, ["", padl <> "Exit (y)?", ""])
 
 ------------------------------------------------------------------------
 
@@ -494,22 +491,22 @@ redrawJustClock = Draw $ discardErrors do
 --
 renderModal :: forall me. ModalElement me => HState -> Size -> IO ()
 renderModal st (Size h w) = do
-   for_ (drawModal @me w st) \(mw, modal') -> do
-       let hoffset = max 0 $ (w - mw) `div` 2
-           mlines  = min h $ length modal'
-           voffset = (h - mlines) `div` 2
-           sty = modals $ config st
-       Curses.wMove Curses.stdScr voffset hoffset
-       for_ (take mlines modal') \t -> do
-            drawLine $ Fast (toWidth mw t) sty
-            (y', _) <- Curses.getYX Curses.stdScr
-            Curses.wMove Curses.stdScr (y'+1) hoffset
+   let (mw, modal') = drawModal @me w st
+       hoffset = max 0 $ (w - mw) `div` 2
+       mlines  = min h $ length modal'
+       voffset = (h - mlines) `div` 2
+       sty = modals $ config st
+   Curses.wMove Curses.stdScr voffset hoffset
+   for_ (take mlines modal') \t -> do
+        drawLine $ Fast (toWidth mw t) sty
+        (y', _) <- Curses.getYX Curses.stdScr
+        Curses.wMove Curses.stdScr (y'+1) hoffset
 
 renderModals :: HState -> Size -> IO ()
-renderModals s sz = do
-   renderModal @HelpModal s sz
-   renderModal @HistModal s sz
-   renderModal @ExitModal s sz
+renderModals st sz = do
+   when (helpVisible st) $ renderModal @HelpModal st sz
+   whenJust (histVisible st) $ const $ renderModal @HistModal st sz
+   when (exitVisible st) $ renderModal @ExitModal st sz
 
 ------------------------------------------------------------------------
 --

--- a/UI.hs
+++ b/UI.hs
@@ -184,8 +184,8 @@ data HelpModal
 data HistModal
 data ExitModal
 class ModalElement a where
-    -- takes style, window width, state; returns (width, list of lines)
-    drawModal :: Style -> Int -> HState -> Maybe (Int, [StringA])
+    -- takes window width, state; returns (width, list of lines)
+    drawModal :: Int -> HState -> Maybe (Int, [ByteString])
 
 ------------------------------------------------------------------------
 
@@ -228,13 +228,13 @@ modalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
 ------------------------------------------------------------------------
 
 instance ModalElement HelpModal where
-    drawModal sty swd st = do
+    drawModal swd st = do
         guard $ helpVisible st
-        pure (wd, [ Fast (f cs h) sty | (h, cs, _) <- keyTable ])
+        pure (wd, [f cs h | (h, cs, _) <- keyTable ])
       where
         wd = modalWidth swd
         f :: [Char] -> String -> ByteString
-        f cs ps = toWidth wd $ toWidth clen cmds <> u ps where
+        f cs ps = toWidth clen cmds <> u ps where
             clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
             cmds = P.unwords ("" : map pprIt cs)
             pprIt c = case c of
@@ -257,24 +257,22 @@ instance ModalElement HelpModal where
 ------------------------------------------------------------------------
 
 instance ModalElement HistModal where
-    drawModal sty swd st = flip fmap (histVisible st) \hist -> do
+    drawModal swd st = flip fmap (histVisible st) \hist -> do
         let wd = modalWidth swd
             mtlen = maximum $ map (displayWidth . fst) hist
             tlen = min (mtlen + 1) $ wd `div` 3
         (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
             let tstr = toMaxWidth tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
-            in Fast (toWidth wd $ " " <> P.singleton c <> " " <> tstr <> " " <> song) sty
+            in mconcat [" ", P.singleton c, " ", tstr, " ", song]
 
 ------------------------------------------------------------------------
 
 instance ModalElement ExitModal where
-    drawModal sty swd st = do
+    drawModal swd st = do
         guard $ exitVisible st
         let wd = modalWidth swd `min` 19
-            blank = Fast (toWidth wd "") sty
             padl = P.replicate ((wd - 9) `div` 2) ' '
-            msg = toWidth wd $ padl <> "Exit (y)?"
-        pure (wd, [blank, Fast msg sty, blank])
+        pure (wd, ["", padl <> "Exit (y)?", ""])
 
 ------------------------------------------------------------------------
 
@@ -497,13 +495,14 @@ redrawJustClock = Draw $ discardErrors do
 --
 renderModal :: forall me. ModalElement me => HState -> Size -> IO ()
 renderModal st (Size h w) = do
-   for_ (drawModal @me (modals $ config st) w st) \(mw, modal') -> do
+   for_ (drawModal @me w st) \(mw, modal') -> do
        let hoffset = max 0 $ (w - mw) `div` 2
            mlines  = min h $ length modal'
            voffset = (h - mlines) `div` 2
+           sty = modals $ config st
        Curses.wMove Curses.stdScr voffset hoffset
        for_ (take mlines modal') \t -> do
-            drawLine w t
+            drawLine w $ Fast (toWidth mw t) sty
             (y', _) <- Curses.getYX Curses.stdScr
             Curses.wMove Curses.stdScr (y'+1) hoffset
 

--- a/UI.hs
+++ b/UI.hs
@@ -52,8 +52,7 @@ u = UTF8.fromString
 
 
 newtype Draw = Draw (IO ())
-instance Semigroup Draw where Draw x <> Draw y = Draw $ x >> y
-instance Monoid Draw where mempty = Draw $ pure ()
+    deriving newtype (Semigroup, Monoid)
 
 runDraw :: Draw -> IO ()
 runDraw (Draw d) = withDrawLock d
@@ -484,9 +483,9 @@ redrawJustClock = Draw $ discardErrors do
     (h, w) <- screenSize
     let dd = DD (Size h w) undefined st (clock st)
     Curses.wMove Curses.stdScr 1 0   -- hardcoded!
-    drawLine w $ progressBar dd
+    drawLine $ progressBar dd
     Curses.wMove Curses.stdScr 2 0   -- hardcoded!
-    drawLine w $ pTimes dd
+    drawLine $ pTimes dd
     when (h < 45) $ renderModals st (Size h w) -- small screen modals paint over clock
 
 ------------------------------------------------------------------------
@@ -502,7 +501,7 @@ renderModal st (Size h w) = do
            sty = modals $ config st
        Curses.wMove Curses.stdScr voffset hoffset
        for_ (take mlines modal') \t -> do
-            drawLine w $ Fast (toWidth mw t) sty
+            drawLine $ Fast (toWidth mw t) sty
             (y', _) <- Curses.getYX Curses.stdScr
             Curses.wMove Curses.stdScr (y'+1) hoffset
 
@@ -528,7 +527,7 @@ redraw = Draw $ discardErrors {- TODO unclear what errors are discarded? -} do
 
     gotoTop
     for_ (take (h-1) (init a)) \t -> do
-        drawLine w t
+        drawLine t
         (y, x) <- Curses.getYX Curses.stdScr
         fillLine
         maybeLineDown t h y x
@@ -538,9 +537,9 @@ redraw = Draw $ discardErrors {- TODO unclear what errors are discarded? -} do
     Curses.wMove Curses.stdScr (h-1) 0
     fillLine
     Curses.wMove Curses.stdScr (h-1) 0
-    drawLine (w-1) (last a)
+    drawLine (last a)
     when (miniFocused st) do -- a fake cursor
-        drawLine 1 (Fast (spaces 1) (blockcursor . config $ st ))
+        drawLine (Fast (spaces 1) (blockcursor . config $ st ))
         -- XXX is this TODO from 2005 still relevant?
         -- todo rendering bug here when deleting backwards in minibuffer
 
@@ -548,9 +547,9 @@ redraw = Draw $ discardErrors {- TODO unclear what errors are discarded? -} do
 --
 -- | Draw a coloured (or not) string to the screen
 --
-drawLine :: Int -> StringA -> IO ()
-drawLine _ (Fast ps sty) = drawSegment ps sty
-drawLine _ (FancyS ls)   = traverse_ (uncurry drawSegment) ls
+drawLine :: StringA -> IO ()
+drawLine (Fast ps sty) = drawSegment ps sty
+drawLine (FancyS ls)   = traverse_ (uncurry drawSegment) ls
 
 -- | Write a single styled UTF-8 segment.  Safe because C only reads the bytes.
 drawSegment :: ByteString -> Style -> IO ()

--- a/UI.hs
+++ b/UI.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
-
 -- Copyright (c) 2004-5 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later

--- a/UI.hs
+++ b/UI.hs
@@ -461,10 +461,7 @@ spaces :: Int -> ByteString
 spaces = flip P.replicate ' '
 
 ------------------------------------------------------------------------
---
 -- | Now write out just the clock line
--- Speed things up a bit, just use read State.
---
 redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
     st     <- getsHS id
@@ -477,9 +474,7 @@ redrawJustClock = Draw $ discardErrors do
     when (h < 45) $ renderModals st (Size h w) -- small screen modals paint over clock
 
 ------------------------------------------------------------------------
---
--- work for drawing help. draw the help screen if it is up
---
+-- | General modal renderer.
 renderModal :: HState -> Size -> ModalMaker -> IO ()
 renderModal st (Size h w) mkr = do
     let (mw, modal') = mkr w
@@ -493,10 +488,10 @@ renderModal st (Size h w) mkr = do
         (y', _) <- Curses.getYX Curses.stdScr
         Curses.wMove Curses.stdScr (y'+1) hoffset
 
+-- | Choose modal to render based on state.
 renderModals :: HState -> Size -> IO ()
-renderModals st sz = do
-    let render = renderModal st sz
-    whenJust (modal st) $ render . \case
+renderModals st sz =
+    whenJust (modal st) $ renderModal st sz . \case
         HelpModal h -> helpModal h
         HistModal h -> histModal h
         ExitModal   -> exitModal
@@ -506,7 +501,7 @@ renderModals st sz = do
 -- | Draw the screen
 --
 redraw :: Draw
-redraw = Draw $ discardErrors {- TODO unclear what errors are discarded? -} do
+redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
     st <- getsHS id    -- another refresh could be triggered?
     (h, w) <- screenSize
     let sz     = Size h w

--- a/UI.hs
+++ b/UI.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, TupleSections, AllowAmbiguousTypes #-}
+{-# LANGUAGE ForeignFunctionInterface, AllowAmbiguousTypes #-}
 
 -- Copyright (c) 2004-5 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2019-2026 Galen Huntington

--- a/UI.hs
+++ b/UI.hs
@@ -415,7 +415,6 @@ playList dd@DD{ drawSize=Size y x, drawPos=Pos{posY=o}, drawState=st } =
     visible = slice off (off + buflen) songs
         where off = screens * buflen
 
-    -- TODO rewrite as fold
     visible' :: [(Maybe Int, ByteString)]
     visible' = loop (-1) visible where
         loop _ []     = []

--- a/UI.hs
+++ b/UI.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, AllowAmbiguousTypes #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
 
 -- Copyright (c) 2004-5 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2019-2026 Galen Huntington
@@ -179,12 +179,8 @@ data DrawData = DD {
     drawFrame :: Maybe Frame
     }
 
-data HelpModal
-data HistModal
-data ExitModal
-class ModalElement a where
-    -- takes window width, state; returns (width, list of lines)
-    drawModal :: Int -> HState -> (Int, [ByteString])
+-- screen width -> (modal width, list of lines)
+type ModalMaker = Int -> (Int, [ByteString])
 
 ------------------------------------------------------------------------
 
@@ -226,49 +222,47 @@ commonModalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
 
 ------------------------------------------------------------------------
 
-instance ModalElement HelpModal where
-    drawModal swd _ = (wd, [f cs h | (h, cs, _) <- keyTable ]) where
-        wd = commonModalWidth swd
-        f :: [Char] -> String -> ByteString
-        f cs ps = toWidth clen cmds <> u ps where
-            clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
-            cmds = P.unwords ("" : map pprIt cs)
-            pprIt c = case c of
-                '\n' -> "Enter"
-                '\f' -> "^L"
-                '\\' -> "\\"
-                ' '  -> "Space"
-                _ -> case charToKey c of
-                    Curses.KeyUp        -> u"↑"
-                    Curses.KeyDown      -> u"↓"
-                    Curses.KeyPPage     -> "PgUp"
-                    Curses.KeyNPage     -> "PgDn"
-                    Curses.KeyLeft      -> u"←"
-                    Curses.KeyRight     -> u"→"
-                    Curses.KeyEnd       -> "End"
-                    Curses.KeyHome      -> "Home"
-                    Curses.KeyBackspace -> "Backspace"
-                    _ -> u[c]
+helpModal :: ModalMaker
+helpModal swd = (wd, [f cs h | (h, cs, _) <- keyTable ]) where
+    wd = commonModalWidth swd
+    f :: [Char] -> String -> ByteString
+    f cs ps = toWidth clen cmds <> u ps where
+        clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
+        cmds = P.unwords ("" : map pprIt cs)
+        pprIt c = case c of
+            '\n' -> "Enter"
+            '\f' -> "^L"
+            '\\' -> "\\"
+            ' '  -> "Space"
+            _ -> case charToKey c of
+                Curses.KeyUp        -> u"↑"
+                Curses.KeyDown      -> u"↓"
+                Curses.KeyPPage     -> "PgUp"
+                Curses.KeyNPage     -> "PgDn"
+                Curses.KeyLeft      -> u"←"
+                Curses.KeyRight     -> u"→"
+                Curses.KeyEnd       -> "End"
+                Curses.KeyHome      -> "Home"
+                Curses.KeyBackspace -> "Backspace"
+                _ -> u[c]
 
 ------------------------------------------------------------------------
 
-instance ModalElement HistModal where
-    drawModal swd st = do
-        let wd = commonModalWidth swd
-            hist = fromJust $ histVisible st
-            mtlen = maximum $ map (displayWidth . fst) hist
-            tlen = min (mtlen + 1) $ wd `div` 3
-        (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
-            let tstr = toMaxWidth tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
-            in mconcat [" ", P.singleton c, " ", tstr, " ", song]
+histModal :: [(ByteString, (Int, ByteString))] -> ModalMaker
+histModal hist swd = do
+    let wd = commonModalWidth swd
+        mtlen = maximum $ map (displayWidth . fst) hist
+        tlen = min (mtlen + 1) $ wd `div` 3
+    (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
+        let tstr = toMaxWidth tlen $ P.replicate (tlen - displayWidth time) ' ' <> time
+        in mconcat [" ", P.singleton c, " ", tstr, " ", song]
 
 ------------------------------------------------------------------------
 
-instance ModalElement ExitModal where
-    drawModal swd _ = do
-        let wd = commonModalWidth swd `min` 19
-            padl = P.replicate ((wd - 9) `div` 2) ' '
-        (wd, ["", padl <> "Exit (y)?", ""])
+exitModal :: ModalMaker
+exitModal swd = (wd, ["", padl <> "Exit (y)?", ""]) where
+    wd = commonModalWidth swd `min` 19
+    padl = P.replicate ((wd - 9) `div` 2) ' '
 
 ------------------------------------------------------------------------
 
@@ -489,24 +483,25 @@ redrawJustClock = Draw $ discardErrors do
 --
 -- work for drawing help. draw the help screen if it is up
 --
-renderModal :: forall me. ModalElement me => HState -> Size -> IO ()
-renderModal st (Size h w) = do
-   let (mw, modal') = drawModal @me w st
-       hoffset = max 0 $ (w - mw) `div` 2
-       mlines  = min h $ length modal'
-       voffset = (h - mlines) `div` 2
-       sty = modals $ config st
-   Curses.wMove Curses.stdScr voffset hoffset
-   for_ (take mlines modal') \t -> do
+renderModal :: HState -> Size -> ModalMaker -> IO ()
+renderModal st (Size h w) mkr = do
+    let (mw, modal') = mkr w
+        hoffset = max 0 $ (w - mw) `div` 2
+        mlines  = min h $ length modal'
+        voffset = (h - mlines) `div` 2
+        sty = modals $ config st
+    Curses.wMove Curses.stdScr voffset hoffset
+    for_ (take mlines modal') \t -> do
         drawLine $ Fast (toWidth mw t) sty
         (y', _) <- Curses.getYX Curses.stdScr
         Curses.wMove Curses.stdScr (y'+1) hoffset
 
 renderModals :: HState -> Size -> IO ()
 renderModals st sz = do
-   when (helpVisible st) $ renderModal @HelpModal st sz
-   whenJust (histVisible st) $ const $ renderModal @HistModal st sz
-   when (exitVisible st) $ renderModal @ExitModal st sz
+    let render = renderModal st sz
+    when (helpVisible st) $ render helpModal
+    whenJust (histVisible st) $ render . histModal
+    when (exitVisible st) $ render exitModal
 
 ------------------------------------------------------------------------
 --

--- a/UI.hs
+++ b/UI.hs
@@ -30,7 +30,7 @@ import Syntax
 import Config
 import Width                    (displayWidth, toMaxWidth, toWidth)
 import qualified UI.HSCurses.Curses as Curses
-import {-# SOURCE #-} Keymap    (keyTable, unkey, charToKey)
+import {-# SOURCE #-} Keymap    (unkey, charToKey)
 
 import Data.Array               ((!), bounds, Array)
 import Data.Array.Base          (unsafeAt)
@@ -222,11 +222,11 @@ commonModalWidth w = max (min w 3) $ round $ fromIntegral w * (0.8::Float)
 
 ------------------------------------------------------------------------
 
-helpModal :: ModalMaker
-helpModal swd = (wd, [f cs h | (h, cs, _) <- keyTable ]) where
+helpModal :: [KeysHelp] -> ModalMaker
+helpModal help swd = (wd, map showLine help) where
     wd = commonModalWidth swd
-    f :: [Char] -> String -> ByteString
-    f cs ps = toWidth clen cmds <> u ps where
+    showLine :: ([Char], String) -> ByteString
+    showLine (cs, ps) = toWidth clen cmds <> u ps where
         clen = max 4 $ round $ fromIntegral wd * (0.2::Float)
         cmds = P.unwords ("" : map pprIt cs)
         pprIt c = case c of
@@ -500,7 +500,7 @@ renderModals :: HState -> Size -> IO ()
 renderModals st sz = do
     let render = renderModal st sz
     whenJust (modal st) $ render . \case
-        HelpModal   -> helpModal
+        HelpModal h -> helpModal h
         HistModal h -> histModal h
         ExitModal   -> exitModal
 

--- a/UI.hs
+++ b/UI.hs
@@ -249,7 +249,7 @@ helpModal help swd = (wd, map showLine help) where
 histModal :: HistDisplay -> ModalMaker
 histModal hist swd = do
     let wd = commonModalWidth swd
-        mtlen = maximum $ map (displayWidth . fst) hist
+        mtlen = maximum $ 0 : map (displayWidth . fst) hist
         tlen = min (mtlen + 1) $ wd `div` 3
     (wd,) $ flip map (zip (['0'..'9']++['a'..'z']) hist) \ (c, (time, (_, song))) ->
         let tstr = toMaxWidth tlen $ P.replicate (tlen - displayWidth time) ' ' <> time

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -26,20 +26,22 @@ source-repository head
 common opts
   default-language: Haskell2010
   default-extensions:
-      BangPatterns
       BlockArguments
-      OverloadedStrings
-      ScopedTypeVariables
-      TypeApplications
-      DerivingVia
-      RecordWildCards
-      LambdaCase
       MultiWayIf
-      StandaloneDeriving
-      NumericUnderscores
-      NamedFieldPuns
+      OverloadedStrings
+      RecordWildCards
+      -- In GHC2024
+      DerivingStrategies
+      LambdaCase
+      -- In GHC2021 (soon!)
+      BangPatterns
       GeneralizedNewtypeDeriving
+      NamedFieldPuns
+      NumericUnderscores
+      ScopedTypeVariables
+      StandaloneDeriving
       TupleSections
+      TypeApplications
   ghc-options: -Wall -funbox-strict-fields
 
 library

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -31,13 +31,14 @@ common opts
       OverloadedStrings
       ScopedTypeVariables
       TypeApplications
-      DerivingStrategies
+      DerivingVia
       RecordWildCards
       LambdaCase
       MultiWayIf
       StandaloneDeriving
       NumericUnderscores
       NamedFieldPuns
+      GeneralizedNewtypeDeriving
   ghc-options: -Wall -funbox-strict-fields
 
 library

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -39,6 +39,7 @@ common opts
       NumericUnderscores
       NamedFieldPuns
       GeneralizedNewtypeDeriving
+      TupleSections
   ghc-options: -Wall -funbox-strict-fields
 
 library


### PR DESCRIPTION
This PR changes how modal states are recorded in HState, and switches rendering from a `ModalElement` class with type-based dispatch to regular functions, analogous to what #90 did for the `Element` class.

*  HState now has a `Maybe Modal` field using new datatypes, which supersedes the three fields for individual modals.  Accessors for manipulating it are exported from `Core.hs`.
*  This representation enforces that only one modal is open at a time.  This also improves (fixes) the former poor UI where the exit modal can appear atop (in the middle of) the help modal.
*  `renderModals` now dispatches to the active modal (if any), rather than invoking all three and having them responsible for knowing whether to render or not.
*  Modal rendering functions, which under `ModalElement` took three arguments and returned a Maybe, are simplified, and in fact the base `ModalMaker` is reduced to one argument:
    *  As noted, modal functions are only invoked when the modal is open, so they don't need to filter for this, removing the Maybe.
    *  The HState no longer needs to be passed in, as it was used to (a) determine if the modal is open, and (b) get the data to display (the history list, now also the help).  We don't need (a) as noted, and for (b) we pass the argument from the `Modal` parameter.  This also makes modal functions more readily testable because we don't have to construct an HState.
    *  Styling is no longer passed in.  It is always the same, so `renderModal` instead is responsible for styling, factoring this out.  The modal functions only return a list of ByteStrings.
    *   The `toWidth` application is also floated out.  This enforces same widths at the `renderModal` level, rather than relying on the modal functions for the invariant.
*  The help table is now a parameter on the `HelpModal` constructor and is inserted in `Keymap.hs`, allowing removal of `keyTable` from the boot file.  This is a step towards getting the boot off our necks.

Tangentially:

*  Extension stuff:
    *  The above work removed one use of `AllowAmbiguousTypes`.  I decided to get rid of the other by using `Proxy`.  Worth doing?  Maybe.
    *  `Draw` uses newtype deriving instead of manual instances.  The extension is added to Cabal.
    *  `TupleSections` is fairly standard and moved to Cabal rather than the individual file.
    *  The FFI extension is in Haskell2010 so isn't needed explicitly.
    *  Extensions in the Cabal file are grouped by future editions.  I intend to switch to GHC2021 when I'm ready to drop GHC 9.0 and lower, which will be soon.  The grouping makes such steps easier.
*  The help descriptions are converted to ByteStrings.  If I need Unicode in descriptions (not expected), I can use `UTF8.fromString` (as I do for the package name, though it's likely to always be ASCII).
*  `whenJust` is proven convenient and added back to `Base.hs` after I formerly thought I could do without it.
*  `drawLine` once took a width argument, which is no longer used, but was still passed in.  This is removed.

Possible future work:

*  `mainMode` could dispatch the key based on the modal state rather than needing other "modes" for that; that is, it would absorb `historyMode` and `confirmQuitMode`.  I believe this is now possible thanks to #76.
*  The hard-coded 45 size cut-off for re-rendering modals on clock refresh is a little ugly.  A few options here.  Easiest might be to never cover the clock.

Net effect:  Six fewer lines of source, but it feels a lot simpler.