### PR TITLE
Change "play under cursor" logic and alter description.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -12,7 +12,7 @@ module Core (
     start,
     shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
-    forcePause, putmsg, clrmsg, play, playCur,
+    forcePause, putmsg, clrmsg, playCursor, playCur,
     jumpToPlaying, jump, jumpRel,
     upPage, downPage,
     seekStart,
@@ -278,7 +278,7 @@ handleMsg (F (File (Left  _))) = modifyHS_ $ \s -> s { id3 = Nothing }
 handleMsg (F (File (Right i))) = modifyHS_ $ \s -> s { id3 = Just i  }
 
 handleMsg (S t) = do
-    modifyHS_ $ \s -> s { status  = t }
+    modifyHS_ $ \s -> s { status = t }
     when (t == Stopped) playNext   -- transition to next song
 
 handleMsg (R f) = do
@@ -358,14 +358,11 @@ blacklist = do
 -- | Operates on HState and outputs maybe a track to play.
 type PlayOp = State HState (Maybe Int)
 
--- | Play the song under the cursor or random if that one is playing
--- TODO these semantics are strange; maybe playNext instead of random?
-play :: IO ()
-play = runPlayOp do
+-- | Play the song under the cursor or next if that one is current
+playCursor :: IO ()
+playCursor = runPlayOp do
     HState { current, cursor } <- get
-    if current == cursor
-        then playRandomOp
-        else pure $ Just cursor
+    if current == cursor then playNextOp else pure $ Just cursor
 
 -- | Play the song under the cursor (from the start)
 playCur :: IO ()
@@ -389,7 +386,10 @@ playPrev = runPlayOp do
 -- If we're at the end, and loop mode is on, then loop to the start
 -- If we're in random mode, play the next random track
 playNext :: IO ()
-playNext = runPlayOp do
+playNext = runPlayOp playNextOp
+
+playNextOp :: PlayOp
+playNextOp = do
     HState { mode, current, size } <- get
     let next = current + 1
     case mode of

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -175,7 +175,7 @@ keyTable =
     , ("Seek left within song",                   [unkey KeyLeft],      seekLeft)
     , ("Seek right within song",                  [unkey KeyRight],     seekRight)
     , ("Toggle pause",                            [' '],                pause)
-    , ("Play song under cursor",                  ['\n'],               play)
+    , ("Play from cursor",                        ['\n'],               playCursor)
     , ("Play previous track",                     ['K'],                playPrev)
     , ("Play next track",                         ['J'],                playNext)
     , ("Toggle the help screen",                  ['h'],                toggleHelp)


### PR DESCRIPTION
This changes the Enter logic, which previously jumped to a random song if the cursor was over the current song.  Instead, it does the appropriate "next" action for the play mode, which might be random, or might be the next song, or might be nothing if in "single" mode.  Basically, it's `J` if cursor is current.  The function name and description are updated to kind of reflect these semantics.