### PR TITLE
Get rid of FiltHandle.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -82,7 +82,7 @@ start opts (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
 
     threads <- traverse forkIO
         [ mpgLoop
-        , mpgInput readf
+        , mpgInput readh
         , refreshLoop
         , clockLoop
         , uptimeLoop
@@ -150,7 +150,7 @@ mpgLoop = runForever do
           Left (ex :: SomeException) ->
             warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
-          Right (writeh, r, e, pid) -> do
+          Right (writeh, readh, errh, pid) -> do
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { mpgPid    = Just pid
                 , status    = Stopped
@@ -159,9 +159,7 @@ mpgLoop = runForever do
                 , spawns    = sp
                 }, sp)
 
-            readf <- newFiltHandle r
-            errh <- newFiltHandle e
-            putMVar mpg Mpg { readf, errh, writeh }
+            putMVar mpg Mpg { readh, errh, writeh }
 
             when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
@@ -228,7 +226,7 @@ clockLoop = runForever $ threadDelay 125_000 *> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    readMVar mpg <&> errh >>= hGetLine . filtHandle >>= (warnA . ("mpg: " ++))
+    readMVar mpg <&> errh >>= hGetLine >>= (warnA . ("mpg: " ++))
 
 ------------------------------------------------------------------------
 
@@ -236,7 +234,7 @@ errorLoop = runForever $
 -- shutdown kills the other end of the pipe, hGetLine will fail, so we
 -- take that chance to exit.
 --
-mpgInput :: (Mpg -> FiltHandle) -> IO ()
+mpgInput :: (Mpg -> Handle) -> IO ()
 mpgInput field = runForever $ do
     res <- parser =<< field <$> readMVar mpg
     case res of
@@ -304,13 +302,10 @@ seekStart = seek $ const 0
 -- | Generic seek
 seek :: (Frame -> Int) -> IO ()
 seek fn = do
-    f <- getsHS clock
-    case f of
-        Nothing -> pure ()
-        Just g  -> do
-            sendMpg $ Jump (fn g)
-            forceNextPacket         -- don't drop the next Frame.
-            silentlyModifyHS $ \st -> st { clockUpdate = True }
+    mfr <- getsHS clock
+    whenJust mfr \fr -> do
+        sendMpg $ Jump (fn fr)
+        silentlyModifyHS $ \st -> st { clockUpdate = True }
 
 
 ------------------------------------------------------------------------

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 -- Copyright (c) 2005-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2008, 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,9 +9,7 @@
 module Lexer ( parser, doP, doF, doS, doI, trim ) where
 
 import Base
-
-import Syntax   (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
-import State    (FiltHandle(..), checkF, getPacket)
+import Syntax (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
 
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
@@ -129,9 +129,9 @@ doI s = let f = trim s
 
 ------------------------------------------------------------------------
 
-parser :: FiltHandle -> IO (Either (Maybe String) Msg)
+parser :: Handle -> IO (Either (Maybe String) Msg)
 parser h = runExceptT do
-    x <- lift $ getPacket h
+    x <- lift $ P.hGetLine h
     -- bad packets are generally just \n in ID3 (and not of interest anyway)
     let skip = throwError Nothing
 
@@ -145,9 +145,7 @@ parser h = runExceptT do
         'R' -> pure $ T Tag
         'I' -> pure $ doI m
         'S' -> pure $ doS m
-        'F' -> do
-            b <- lift $ checkF h
-            if b then pure $ doF m else skip
+        'F' -> pure $ doF m
         'P' -> pure $ doP m
         'E' -> throwError $ Just $ "mpg123 error: " ++ P.unpack m
         _   -> skip

--- a/State.hs
+++ b/State.hs
@@ -17,7 +17,6 @@ import qualified Config (defaultStyle)
 import Text.Regex.PCRE.Light    (Regex)
 import Data.Array               (listArray)
 import Data.ByteString          (hPut)
-import qualified Data.ByteString.Char8 as P
 import Data.Sequence            (Seq)
 import System.Clock             (TimeSpec(..))
 import System.IO                (hFlush)
@@ -123,34 +122,12 @@ hState = unsafePerformIO $ newMVar =<< newEmptyHS
 {-# NOINLINE hState #-}
 
 ------------------------------------------------------------------------
--- The decoder process's pipes, and the frame-sampling counter.
-
---  Use every nth frame.  1 for no dropping.
-dropRate :: Int
-dropRate = 4   -- used to be 10, but computers are faster
-
--- | A read handle from the decoder, paired with a counter used to sample
--- one in every 'dropRate' @F frames (there are far more than we need).
-data FiltHandle = FiltHandle { filtHandle :: !Handle, frameCount :: !(IORef Int) }
-
-newFiltHandle :: Handle -> IO FiltHandle
-newFiltHandle h = FiltHandle h <$> newIORef 0
-
--- | Read a line from a stream connected to the decoder process.
-getPacket :: FiltHandle -> IO ByteString
-getPacket (FiltHandle fp _) = P.hGetLine fp
-
--- | Is this one of every 'dropRate' packets?  (Always, if dropRate == 1.)
-checkF :: FiltHandle -> IO Bool
-checkF (FiltHandle _ ir) = do
-  modifyIORef' ir (\x -> (x+1) `mod` dropRate)
-  i <- readIORef ir
-  pure $ dropRate == 1 || i == 1
+-- The decoder.
 
 data Mpg = Mpg
     { writeh :: !Handle
-    , readf  :: !FiltHandle
-    , errh   :: !FiltHandle
+    , readh  :: !Handle
+    , errh   :: !Handle
     }
 
 mpg :: MVar Mpg
@@ -182,11 +159,6 @@ modifyHS f = modifyMVar hState (pure . f) <* touchHS
 -- | Trigger a refresh. This is the only way to update the screen.
 touchHS :: IO ()
 touchHS = withMVar hState \st -> void $ tryPutMVar (modified st) ()
-
-forceNextPacket :: IO ()
-forceNextPacket = do
-  fh <- readf <$> readMVar mpg
-  writeIORef (frameCount fh) 0
 
 withDrawLock :: IO () -> IO ()
 withDrawLock io = do

--- a/Syntax.hs
+++ b/Syntax.hs
@@ -106,10 +106,6 @@ newtype Info = Info {
 -- Frame decoding status updates (once per frame).
 -- Current-frame and frames-remaining are integers; current-time and
 -- time-remaining floating point numbers with two decimal places.
---
--- Only 1 frame a second is actually read, so make sure it's lazy so
--- there's no need to evaluate all the others. 
--- 
 data Frame = Frame {
                 currentFrame   :: !Int,
                 framesLeft     :: !Int,
@@ -148,3 +144,4 @@ data Msg = T {-# UNPACK #-} !Tag
          | R {-# UNPACK #-} !Frame
          | S                !Status
     deriving stock (Eq, Show)
+


### PR DESCRIPTION
This abstraction throttled incoming messages (10 per second) from `mpg123` on music file progress.  However, all that we do with these messages is update the state, which is a very cheap operation (microseconds likely).  We don't do a refresh or anything like that.  So this simply isn't needed.  As another argument, this was created in 2005 with a "drop rate" of 10, and computers are more than 10× faster today.

Dropping this feature allows some nice simplification, since it was a bit fiddly in places.