### PR TITLE
Message setters induce refresh.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -12,7 +12,7 @@ module Core (
     start,
     shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
-    forcePause, putmsg, clrmsg, playCursor, playCur,
+    forcePause, putMessage, clearMessage, playCursor, playCur,
     jumpToPlaying, jump, jumpRel,
     upPage, downPage,
     seekStart,
@@ -501,7 +501,7 @@ genericJumpToMatch re sw k sel = do
                 i:_ -> (st' { cursor = sel i st }, True)
                 _   -> (st', False)
 
-    unless found $ putmsg (Fast "No match found." defaultSty) *> touchHS
+    unless found $ putMessage $ Fast "No match found." defaultSty
 
 ------------------------------------------------------------------------
 
@@ -585,20 +585,16 @@ loadConfig = do
     UI.resetui
 
 ------------------------------------------------------------------------
--- Editing the minibuffer
+-- Set the minibuffer
 
--- TODO maybe shouldn't be silent?
-putmsg :: StringA -> IO ()
-putmsg s = silentlyModifyHS $ \st -> st { minibuffer = s }
+putMessage :: StringA -> IO ()
+putMessage s = modifyHS_ \st -> st { minibuffer = s }
 
--- | Modify without triggering a refresh
-clrmsg :: IO ()
-clrmsg = putmsg (Fast P.empty defaultSty)
+clearMessage :: IO ()
+clearMessage = putMessage $ Fast P.empty defaultSty
 
---
 warnA :: String -> IO ()
 warnA x = do
     sty <- getsHS config
-    putmsg $ Fast (P.pack x) (warnings sty)
-    touchHS
+    putMessage $ Fast (P.pack x) (warnings sty)
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -41,7 +41,7 @@ newtype KeyMap = KeyMap (Char -> IO KeyMap)
 -- action remain visible until the user reacts.
 keyLoop :: IO ()
 keyLoop = go mainMode where
-    go (KeyMap f) = UI.getKey >>= \c -> clrmsg *> f c >>= go
+    go (KeyMap f) = UI.getKey >>= \c -> clearMessage *> f c >>= go
 
 
 ------------------------------------------------------------------------
@@ -90,7 +90,7 @@ searchMode stype = step where
     step z = renderSearch stype z $> KeyMap (`dispatch` z)
 
     dispatch c z
-        | c == '\ESC'      = clrmsg *> touchHS *> leave
+        | c == '\ESC'      = clearMessage *> leave
         | c `elem` enter'  = commit z
         | c `elem` delete' = step $ zipEdit dropLast z
         | k == KeyUp       = step $ zipUp z
@@ -100,7 +100,7 @@ searchMode stype = step where
         | otherwise        = step $ zipEdit (++ [c]) z
       where k = charToKey c
 
-    commit (Zipper []  _ _) = clrmsg *> touchHS *> leave
+    commit (Zipper []  _ _) = clearMessage *> leave
     commit (Zipper pat _ _) = do
         let jumpy = if stype `elem` ['/', '?']
                     then jumpToMatchFile else jumpToMatchDir
@@ -118,9 +118,7 @@ searchMode stype = step where
     leave = toggleFocus $> mainMode
 
 renderSearch :: Char -> Zipper -> IO ()
-renderSearch prefix z = do
-    putmsg $ Fast (P.pack (prefix : cur z)) defaultSty
-    touchHS
+renderSearch prefix z = putMessage $ Fast (P.pack (prefix : cur z)) defaultSty
 
 dropLast :: [a] -> [a]
 dropLast [] = []

--- a/Style.hs
+++ b/Style.hs
@@ -10,7 +10,7 @@ module Style where
 
 import Base
 import qualified UI.HSCurses.Curses as Curses
-import qualified Data.Map as M  (fromList, empty, lookup, Map)
+import qualified Data.Map as M
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #86.  Almost all usages already did a manual "touch" afterwards anyway.  Those that didn't might as well, and the delayed display accomplishes very little, nor do I see the flexibility as useful.

The only real difference is that an invalid (unbound) key in main mode will clear the minibuffer now, whereas it didn't before.  This is an inconsiderable change.

Accessors are given somewhat nicer names.

Left over from another branch, some needlessly enumerated imports are removed.