### PR TITLE
Draw work: make MVars top-level, remove TERM magic.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -25,7 +25,6 @@ import Data.String as X
 import Data.Traversable as X
 import Data.Version as X
 import Data.Word as X
-import System.Environment as X
 import System.Exit as X
 import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X

--- a/Core.hs
+++ b/Core.hs
@@ -260,7 +260,7 @@ shutdown ms = do
     whenJust mpid \pid -> do
         discardErrors $ sendMpg Quit
         void $ waitForProcess pid
-    UI.end =<< getsHS xterm
+    UI.end
     whenJust ms \s -> hPutStrLn stderr s *> hFlush stderr
     exitImmediately ExitSuccess
 

--- a/Core.hs
+++ b/Core.hs
@@ -183,9 +183,8 @@ mpgLoop = runForever do
 -- | When the editor state has been modified, refresh, then wait
 -- for it to be modified again.
 refreshLoop :: IO ()
-refreshLoop = do
-    mvar <- getsHS modified
-    runForever $ takeMVar mvar >> UI.refresh
+refreshLoop = runForever $ takeMVar modified *> UI.refresh
+
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -91,6 +91,8 @@ start opts (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
         , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
         ]
 
+    putMVar hState =<< newEmptyHS
+
     silentlyModifyHS $ \st -> st
         { music        = fs
         , folders      = ds

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -18,7 +18,7 @@ import Base hiding ((!?))
 
 import Core
 import Config (package)
-import State (getsHS, touchHS, modifyHS_, KeysHelp, Modal(..), HState(..))
+import State (getsHS, modifyHS_, KeysHelp, Modal(..), HState(..))
 import Style (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
 
@@ -52,12 +52,12 @@ mainMode = KeyMap \c -> getsHS modal >>= \case
 
     Just ExitModal -> case c of
         'y' -> shutdown Nothing $> undefined -- shutdown never returns
-        _   -> closeModal *> touchHS $> mainMode
+        _   -> closeModal $> mainMode
 
     Just (HistModal hist) -> do
         let xs !? n = listToMaybe $ drop n xs -- Compat: List.!? added in GHC 9.8
         for_ (M.lookup c historyKeyMap >>= (hist !?)) (jump . fst . snd)
-        closeModal *> touchHS $> mainMode
+        closeModal $> mainMode
 
     _ -> if
         | c `elem` ['/', '?', '\\', '|'] -> do
@@ -67,7 +67,7 @@ mainMode = KeyMap \c -> getsHS modal >>= \case
         | c == 'q' ->
             forcePause *> setsModal (const $ Just ExitModal) $> mainMode
         | c `elem` ['H', ';'] ->
-            showHist *> touchHS $> mainMode
+            showHist $> mainMode
         | c >= '1' && c <= '9' ->
             jumpRel (0.1 * fromIntegral (fromEnum c - 48)) $> mainMode
         | True -> sequence_ (M.lookup c keyMap) $> mainMode

--- a/State.hs
+++ b/State.hs
@@ -52,7 +52,6 @@ data HState = HState {
        ,playHist        :: !(Seq (TimeSpec, Int)) -- limited history of songs played
        ,config          :: !UIStyle             -- config values
        ,configPath      :: !(Maybe FilePath)     -- style.conf override (CLI)
-
     }
 
 -- Each is (timestamp-string, (song-index, song-name)).
@@ -106,7 +105,7 @@ newEmptyHS = do
 
 -- | A global variable holding the state.
 hState :: MVar HState
-hState = unsafePerformIO $ newMVar =<< newEmptyHS
+hState = unsafePerformIO newEmptyMVar
 {-# NOINLINE hState #-}
 
 -- | The refresh thread waits on this

--- a/State.hs
+++ b/State.hs
@@ -48,7 +48,6 @@ data HState = HState {
        ,boottime        :: !TimeSpec
        ,regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
        ,searchHist      :: ![String]             -- history of searches
-       ,xterm           :: !Bool
        ,doNotResuscitate :: !Bool                -- should we just let mpg123 die?
        ,playHist        :: !(Seq (TimeSpec, Int)) -- limited history of songs played
        ,config          :: !UIStyle             -- config values
@@ -57,7 +56,6 @@ data HState = HState {
        ,modified        :: !(MVar ())           -- Set when redrawable components of 
                                                 -- the state are modified. The ui
                                                 -- refresh thread waits on this.
-       ,drawLock        :: !(MVar ())           -- simple semaphore for display
     }
 
 -- Each is (timestamp-string, (song-index, song-name)).
@@ -75,7 +73,6 @@ data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
 newEmptyHS :: IO HState
 newEmptyHS = do
     modified  <- newEmptyMVar
-    drawLock  <- newMVar ()
     randomGen <- newStdGen
     pure HState {
         music        = listArray (0,0) []
@@ -99,7 +96,6 @@ newEmptyHS = do
        ,clockUpdate      = False
        ,modal            = Nothing
        ,miniFocused      = False
-       ,xterm            = False
        ,doNotResuscitate = False    -- mpg123 should be restarted
 
        ,randomGen
@@ -111,7 +107,6 @@ newEmptyHS = do
        ,mode         = minBound
        ,minibuffer   = Fast mempty defaultSty
        ,uptime       = mempty
-       ,drawLock
     }
 
 --
@@ -159,9 +154,4 @@ modifyHS f = modifyMVar hState (pure . f) <* touchHS
 -- | Trigger a refresh. This is the only way to update the screen.
 touchHS :: IO ()
 touchHS = withMVar hState \st -> void $ tryPutMVar (modified st) ()
-
-withDrawLock :: IO () -> IO ()
-withDrawLock io = do
-    lock <- getsHS drawLock
-    withMVar lock $ const io
 

--- a/State.hs
+++ b/State.hs
@@ -53,9 +53,6 @@ data HState = HState {
        ,config          :: !UIStyle             -- config values
        ,configPath      :: !(Maybe FilePath)     -- style.conf override (CLI)
 
-       ,modified        :: !(MVar ())           -- Set when redrawable components of 
-                                                -- the state are modified. The ui
-                                                -- refresh thread waits on this.
     }
 
 -- Each is (timestamp-string, (song-index, song-name)).
@@ -72,7 +69,6 @@ data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
 --
 newEmptyHS :: IO HState
 newEmptyHS = do
-    modified  <- newEmptyMVar
     randomGen <- newStdGen
     pure HState {
         music        = listArray (0,0) []
@@ -83,7 +79,6 @@ newEmptyHS = do
        ,cursor       = 0
 
        ,threads      = []
-       ,modified
 
        ,mpgPid       = Nothing
        ,spawns       = 0
@@ -109,12 +104,19 @@ newEmptyHS = do
        ,uptime       = mempty
     }
 
---
 -- | A global variable holding the state.
---
 hState :: MVar HState
 hState = unsafePerformIO $ newMVar =<< newEmptyHS
 {-# NOINLINE hState #-}
+
+-- | The refresh thread waits on this
+modified :: MVar ()
+modified = unsafePerformIO newEmptyMVar
+{-# NOINLINE modified #-}
+
+-- | Queues a refresh.
+setModified :: IO ()
+setModified = void $ tryPutMVar modified ()
 
 ------------------------------------------------------------------------
 -- The decoder.
@@ -140,18 +142,14 @@ sendMpg s = withMVar mpg $ (. writeh) \h ->
 getsHS :: (HState -> a) -> IO a
 getsHS f = f <$> readMVar hState
 
--- | Modify the state with a pure function
+-- | Modify the state with a pure function and no refresh
 silentlyModifyHS :: (HState -> HState) -> IO ()
 silentlyModifyHS  f = modifyMVar_ hState (pure . f)
 
 modifyHS_ :: (HState -> HState) -> IO ()
-modifyHS_ f = silentlyModifyHS f <* touchHS
+modifyHS_ f = silentlyModifyHS f <* setModified
 
 -- | Modify the state returning a value
 modifyHS :: (HState -> (HState, a)) -> IO a
-modifyHS f = modifyMVar hState (pure . f) <* touchHS
-
--- | Trigger a refresh. This is the only way to update the screen.
-touchHS :: IO ()
-touchHS = withMVar hState \st -> void $ tryPutMVar (modified st) ()
+modifyHS f = modifyMVar hState (pure . f) <* setModified
 

--- a/UI.hs
+++ b/UI.hs
@@ -13,7 +13,7 @@
 module UI (
     runDraw,
     -- * Construction, destruction
-    start, end, suspend, screenSize, refresh, refreshClock, resetui,
+    start, end, screenSize, refresh, refreshClock, resetui,
     -- * Input
     getKey
   ) where
@@ -33,7 +33,7 @@ import Data.Array               ((!), bounds, Array)
 import Data.Array.Base          (unsafeAt)
 import System.Posix.FilePath    (takeFileName)
 import System.IO                (stderr, hFlush)
-import System.Posix.Signals     (raiseSignal, sigTSTP, installHandler, Handler(..))
+import System.Posix.Signals     (installHandler, Handler(..))
 
 import Foreign.C.String
 import Foreign.C.Types
@@ -52,23 +52,20 @@ u = UTF8.fromString
 newtype Draw = Draw (IO ())
     deriving newtype (Semigroup, Monoid)
 
+drawLock :: MVar ()
+drawLock = unsafePerformIO $ newMVar ()
+{-# NOINLINE drawLock #-}
+
 runDraw :: Draw -> IO ()
-runDraw (Draw d) = withDrawLock d
+runDraw (Draw io) = withMVar drawLock $ const io
 
 ------------------------------------------------------------------------
 
 -- | Initialize the UI
 start :: IO UIStyle
 start = do
-    discardErrors do
-        thisterm <- lookupEnv "TERM"
-        case thisterm of 
-            Just "vt220" -> setEnv "TERM" "xterm-color"
-            Just t | "xterm" `isPrefixOf` t 
-                   -> silentlyModifyHS $ \st -> st { xterm = True }
-            _ -> pure ()
-
     Curses.initCurses
+
     case Curses.cursesSigWinch of
         Just wch -> void $ installHandler wch (Catch resetui) Nothing
         _        -> pure () -- handled elsewhere
@@ -90,23 +87,14 @@ resetui = runDraw (resizeui <> nocursor) *> refresh
 nocursor :: Draw
 nocursor = Draw $ discardErrors $ void $ Curses.cursSet Curses.CursorInvisible
 
---
--- | Clean up and go home. Refresh is needed on linux. grr.
---
-end :: Bool -> IO ()
-end isXterm = withDrawLock do
-    when isXterm $ setXtermTitle ["xterm"]
+-- | Clean up and go home.
+end :: IO ()
+end = do
+    takeMVar drawLock        -- we keep so no one tries to draw
+    setXtermTitle ["xterm"]  -- XXX I don't see this title after exit?
     Curses.endWin
 
---
--- | Suspend the program
---
-suspend :: IO ()
-suspend = raiseSignal sigTSTP
-
---
 -- | Find the current screen height and width.
---
 screenSize :: IO (Int, Int)
 screenSize = Curses.scrSize
 
@@ -508,7 +496,7 @@ redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
         screen = playScreen (DD sz (Pos 0 0) st (clock st))
         a      = screen ++ playList (DD sz (Pos (length screen) 0) st (clock st))
 
-    when (xterm st) $ setXterm st
+    setXterm st
 
     gotoTop
     for_ (take (h-1) (init a)) \t -> do


### PR DESCRIPTION
*  The `drawLock` and `modified` MVars are taken out of the HState and made top-level, since they don't belong in there, and the former being in there blocked the planned change of delaying population of the HState.
*  `touchHS` is appropriately renamed to `setModified`.  Also, I found many invocations of it were redundant and could be removed.
*  `drawLock` is moved.
*  The checking of `TERM` to guess xterm capabilities is removed since it is not a very good heuristic.  Modern terminals should simply ignore the title setting if they don't support it, so we can always try (other attempts to detect the capability didn't work well).  This disposes of the `xterm` setting.
*  Similarly, the manual `TERM=vt220` override must have been from another era and isn't needed now.
*  `UI.end` keeps the draw lock so no thread gets any idea to continue to drawing in the event it gets the chance to before the process terminates.
*  The unused `suspend` function is removed.