### PR TITLE
Don't start state with dummy values.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -50,7 +50,7 @@ import System.Directory         (doesFileExist, findExecutable, createDirectoryI
 import System.IO                (hPutStrLn, hGetLine, stderr, hFlush)
 import System.Process           (runInteractiveProcess, waitForProcess)
 import System.Clock             (TimeSpec(..), diffTimeSpec)
-import System.Random            (randomR)
+import System.Random            (randomR, newStdGen)
 import System.FilePath          ((</>))
 import System.Posix.FilePath    (takeFileName)
 
@@ -74,12 +74,15 @@ data Options = Options
     }
 
 start :: Options -> Tree -> IO ()
-start opts (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
+start opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
 
-    c <- UI.start -- initialise curses
-
-    now <- getMonoTime
+    config <- UI.start
+    bootTime <- getMonoTime
+    let size = length music
     mode <- readState
+    gen <- newStdGen
+    let (current, randomGen) =
+            if mode == Random then randomR (0, size-1) gen else (0, gen)
 
     threads <- traverse forkIO
         [ mpgLoop
@@ -91,24 +94,39 @@ start opts (Tree ds fs) = handle @SomeException (shutdown . Just . show) do
         , if mp3Tool == "mpg321" then mpgInput errh else errorLoop
         ]
 
-    putMVar hState =<< newEmptyHS
-
-    silentlyModifyHS $ \st -> st
-        { music        = fs
-        , folders      = ds
-        , size         = 1 + (snd . bounds $ fs)
-        , cursor       = 0
-        , current      = 0
-        , mode         = mode
-        , boottime     = now
-        , config       = c
+    putMVar hState HState
+        { music
+        , folders
+        , size
+        , bootTime
         , configPath   = optConfigPath opts
-        , threads      }
+        , current
+        , cursor       = current
+        , randomGen
+        , mode
+        , config
+        , threads
+        , spawns       = 0
+        , mpgPid       = Nothing
+        , clock        = Nothing
+        , info         = Nothing
+        , id3          = Nothing
+        , regex        = Nothing
+        , modal        = Nothing
+        , playHist     = mempty
+        , searchHist   = []
+        , clockUpdate  = False
+        , miniFocused  = False
+        , exiting      = False
+        , status       = Stopped
+        , minibuffer   = Fast mempty defaultSty
+        , uptime       = mempty
+        }
 
-    loadConfig
+    loadConfig  -- TODO this should return config rather than setting it
 
-    if mode == Random then runPlayOp playRandomOp else playCur
-    when (optPaused opts) pause
+    playCur
+    when (optPaused opts) pause -- TODO use LOADPAUSED?
 
     run         -- won't restart if this fails!
 
@@ -171,7 +189,7 @@ mpgLoop = runForever do
             silentlyModifyHS $ \st -> st { mpgPid = Nothing }
             void $ takeMVar mpg
 
-            stop <- getsHS doNotResuscitate
+            stop <- getsHS exiting
             when stop exitSuccess
             threadDelay 1_000_000  -- let threads spit errors
             warnA $ "Restarting " ++ mppath ++ " ..."
@@ -194,7 +212,7 @@ refreshLoop = runForever $ takeMVar modified *> UI.refresh
 uptimeLoop :: IO ()
 uptimeLoop = runForever $ do
     now <- getMonoTime
-    modifyHS_ $ \st -> st { uptime = showTimeDiff (boottime st) now }
+    modifyHS_ $ \st -> st { uptime = showTimeDiff (bootTime st) now }
     threadDelay 3_000_000
 
 ------------------------------------------------------------------------
@@ -255,7 +273,7 @@ run = runForever keyLoop
 -- | Close most things. Important to do all the jobs:
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
-    silentlyModifyHS $ \st -> st { doNotResuscitate = True }
+    silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState
     mpid <- getsHS mpgPid
     whenJust mpid \pid -> do

--- a/State.hs
+++ b/State.hs
@@ -12,46 +12,47 @@ import Base
 import Syntax                   (Status(Stopped), Mode(..), Frame, Info, Id3, Pretty(ppr))
 import Tree                     (FileArray, DirArray)
 import Style                    (StringA(Fast), defaultSty, UIStyle)
-import qualified Config (defaultStyle)
+import qualified Config         (defaultStyle)
 
-import Text.Regex.PCRE.Light    (Regex)
-import Data.Array               (listArray)
 import Data.ByteString          (hPut)
 import Data.Sequence            (Seq)
 import System.Clock             (TimeSpec(..))
 import System.IO                (hFlush)
 import System.Process           (ProcessHandle)
-import System.Random
+import System.Random            (StdGen)
+import Text.Regex.PCRE.Light    (Regex)
 
 
--- | The editor state type
-data HState = HState {
-        music           :: !FileArray
-       ,folders         :: !DirArray
-       ,size            :: !Int                  -- cache size of list
-       ,current         :: !Int                  -- currently playing mp3
-       ,cursor          :: !Int                  -- mp3 under the cursor
-       ,clock           :: !(Maybe Frame)        -- current clock value
-       ,clockUpdate     :: !Bool
-       ,randomGen       :: !StdGen               -- random seed
-       ,mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
-       ,spawns          :: !Integer              -- count of decoder spawns
-       ,threads         :: ![ThreadId]           -- all our threads
-       ,id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
-       ,info            :: !(Maybe Info)         -- mp3 info
-       ,status          :: !Status
-       ,minibuffer      :: !StringA              -- contents of minibuffer
-       ,modal           :: !(Maybe Modal)        -- modal visible
-       ,miniFocused     :: !Bool                 -- is the mini buffer focused?
-       ,mode            :: !Mode
-       ,uptime          :: !ByteString
-       ,boottime        :: !TimeSpec
-       ,regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
-       ,searchHist      :: ![String]             -- history of searches
-       ,doNotResuscitate :: !Bool                -- should we just let mpg123 die?
-       ,playHist        :: !(Seq (TimeSpec, Int)) -- limited history of songs played
-       ,config          :: !UIStyle             -- config values
-       ,configPath      :: !(Maybe FilePath)     -- style.conf override (CLI)
+-- | Player state
+data HState = HState
+    -- These never change
+    { music           :: !FileArray
+    , folders         :: !DirArray
+    , size            :: !Int                  -- cache size of list
+    , bootTime        :: !TimeSpec
+    , configPath      :: !(Maybe FilePath)     -- style.conf override (CLI)
+    -- These can
+    , current         :: !Int                  -- currently playing mp3
+    , cursor          :: !Int                  -- mp3 under the cursor
+    , clock           :: !(Maybe Frame)        -- current clock value
+    , clockUpdate     :: !Bool
+    , randomGen       :: !StdGen               -- random seed
+    , mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
+    , spawns          :: !Integer              -- count of decoder spawns
+    , threads         :: ![ThreadId]           -- all our threads
+    , id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
+    , info            :: !(Maybe Info)         -- mp3 info
+    , status          :: !Status
+    , minibuffer      :: !StringA              -- contents of minibuffer
+    , modal           :: !(Maybe Modal)        -- modal visible
+    , miniFocused     :: !Bool                 -- is the mini buffer focused?
+    , mode            :: !Mode
+    , uptime          :: !ByteString
+    , regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
+    , searchHist      :: ![String]
+    , exiting         :: !Bool                 -- let mpg123 die?
+    , playHist        :: !(Seq (TimeSpec, Int))
+    , config          :: !UIStyle
     }
 
 -- Each is (timestamp-string, (song-index, song-name)).
@@ -61,47 +62,6 @@ type HistDisplay = [(ByteString, (Int, ByteString))]
 type KeysHelp = ([Char], ByteString)
 
 data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
-
-------------------------------------------------------------------------
---
--- | The initial state
---
-newEmptyHS :: IO HState
-newEmptyHS = do
-    randomGen <- newStdGen
-    pure HState {
-        music        = listArray (0,0) []
-       ,folders      = listArray (0,0) []
-
-       ,size         = 0
-       ,current      = 0
-       ,cursor       = 0
-
-       ,threads      = []
-
-       ,mpgPid       = Nothing
-       ,spawns       = 0
-       ,clock        = Nothing
-       ,info         = Nothing
-       ,id3          = Nothing
-       ,regex        = Nothing
-       ,searchHist   = []
-
-       ,clockUpdate      = False
-       ,modal            = Nothing
-       ,miniFocused      = False
-       ,doNotResuscitate = False    -- mpg123 should be restarted
-
-       ,randomGen
-       ,playHist     = mempty
-       ,config       = Config.defaultStyle
-       ,configPath   = Nothing
-       ,boottime     = 0
-       ,status       = Stopped
-       ,mode         = minBound
-       ,minibuffer   = Fast mempty defaultSty
-       ,uptime       = mempty
-    }
 
 -- | A global variable holding the state.
 hState :: MVar HState


### PR DESCRIPTION
Unlocked by #100, this removes the population of `hState` with dummy/nonsense values on start-up.  Instead, the MVar is initially empty, and only filled with correct values.  This avoids extra code to fill the fields with garbage, and is a simpler model in that there is no need to worry about a thread somehow seeing the invalid data.

Minor:

*  `boottime` to `bootTime`
*  `doNotRescusciate` to `exiting` (shorter, and expresses why rather than what)
*  some reformatting, etc.