### PR TITLE
Make Lexer functions total and somewhat update ID3 parsing for current mpg123.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -13,7 +13,6 @@ import Prelude
 import Control.Concurrent as X
 import Control.Exception as X
 import Control.Monad as X
-import Data.Bifunctor as X
 import Data.ByteString as X (ByteString)
 import Data.Char as X
 import Data.Fixed as X

--- a/Base.hs
+++ b/Base.hs
@@ -20,7 +20,7 @@ import Data.Fixed as X
 import Data.Foldable as X
 import Data.Functor as X hiding (unzip)
 import Data.IORef as X
-import Data.List as X
+import Data.List as X hiding ((!?))
 import Data.Maybe as X
 import Data.String as X
 import Data.Traversable as X
@@ -50,4 +50,8 @@ getMonoTime = getTime
 
 whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
 whenJust = flip $ maybe $ pure ()
+
+-- Compatibility: List.!? only added in GHC 9.8
+(!?) :: [a] -> Int -> Maybe a
+xs !? n = listToMaybe $ drop n xs
 

--- a/Base.hs
+++ b/Base.hs
@@ -13,6 +13,7 @@ import Prelude
 import Control.Concurrent as X
 import Control.Exception as X
 import Control.Monad as X
+import Data.Bifunctor as X
 import Data.ByteString as X (ByteString)
 import Data.Char as X
 import Data.Fixed as X

--- a/Core.hs
+++ b/Core.hs
@@ -271,9 +271,9 @@ shutdown ms = do
 --
 handleMsg :: Msg -> IO ()
 
-handleMsg (T _)        = pure ()
-handleMsg (I i)        = modifyHS_ $ \s -> s { info = Just i }
-handleMsg (F (File f)) = modifyHS_ $ \s -> s { id3 = find (const True) f }
+handleMsg (T _)   = pure ()
+handleMsg (I i)   = modifyHS_ $ \s -> s { info = Just i }
+handleMsg (F id3) = modifyHS_ $ \s -> s { id3 = Just id3 }
 
 handleMsg (S t) = do
     modifyHS_ $ \s -> s { status = t }
@@ -420,6 +420,7 @@ runPlayOp op = do
                 , status  = Playing
                 , cursor  = if current == cursor then new else cursor
                 , playHist = Seq.take 36 $ (now, new) Seq.<| playHist
+                , id3     = Nothing
                 }
             pure f
     forM_ mfile $ sendMpg . Load

--- a/Core.hs
+++ b/Core.hs
@@ -240,7 +240,7 @@ mpgInput field = runForever $ do
     line <- P.hGetLine =<< field <$> readMVar mpg
     case mpgParser line of
         Right m       -> handleMsg m
-        Left (Just e) -> warnA ("mpg123: " ++ show e)
+        Left (Just e) -> warnA ("mpg123: " ++ e)
         _             -> pure ()
 
 ------------------------------------------------------------------------
@@ -270,6 +270,7 @@ shutdown ms = do
 -- right pigeon hole.
 --
 handleMsg :: Msg -> IO ()
+
 handleMsg (T _)        = pure ()
 handleMsg (I i)        = modifyHS_ $ \s -> s { info = Just i }
 handleMsg (F (File f)) = modifyHS_ $ \s -> s { id3 = find (const True) f }

--- a/Core.hs
+++ b/Core.hs
@@ -28,7 +28,7 @@ module Core (
 import Base
 
 import Syntax
-import Lexer                (parser)
+import Lexer (mpgParser)
 import State
 import Style
 import Tree hiding (File, Dir)
@@ -227,7 +227,7 @@ clockLoop = runForever $ threadDelay 125_000 *> UI.refreshClock
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
-    readMVar mpg <&> errh >>= hGetLine >>= (warnA . ("mpg: " ++))
+    readMVar mpg <&> errh >>= hGetLine >>= (warnA . ("mpg123 err: " ++))
 
 ------------------------------------------------------------------------
 
@@ -237,10 +237,10 @@ errorLoop = runForever $
 --
 mpgInput :: (Mpg -> Handle) -> IO ()
 mpgInput field = runForever $ do
-    res <- parser =<< field <$> readMVar mpg
-    case res of
+    line <- P.hGetLine =<< field <$> readMVar mpg
+    case mpgParser line of
         Right m       -> handleMsg m
-        Left (Just e) -> (warnA . ("read: " ++) . show) e
+        Left (Just e) -> warnA ("mpg123: " ++ show e)
         _             -> pure ()
 
 ------------------------------------------------------------------------
@@ -270,10 +270,9 @@ shutdown ms = do
 -- right pigeon hole.
 --
 handleMsg :: Msg -> IO ()
-handleMsg (T _)                = pure ()
-handleMsg (I i)                = modifyHS_ $ \s -> s { info = Just i }
-handleMsg (F (File (Left  _))) = modifyHS_ $ \s -> s { id3 = Nothing }
-handleMsg (F (File (Right i))) = modifyHS_ $ \s -> s { id3 = Just i  }
+handleMsg (T _)        = pure ()
+handleMsg (I i)        = modifyHS_ $ \s -> s { info = Just i }
+handleMsg (F (File f)) = modifyHS_ $ \s -> s { id3 = find (const True) f }
 
 handleMsg (S t) = do
     modifyHS_ $ \s -> s { status = t }

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -14,7 +14,7 @@
 --
 module Keymap (keyLoop, keyTable, unkey, charToKey) where
 
-import Base hiding ((!?))
+import Base
 
 import Core
 import Config (package)
@@ -55,7 +55,6 @@ mainMode = KeyMap \c -> getsHS modal >>= \case
         _   -> closeModal *> touchHS $> mainMode
 
     Just (HistModal hist) -> do
-        let xs !? n = listToMaybe $ drop n xs -- Compat: List.!? added in GHC 9.8
         for_ (M.lookup c historyKeyMap >>= (hist !?)) (jump . fst . snd)
         closeModal *> touchHS $> mainMode
 

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -72,6 +72,8 @@ doI s = F <$> do
     guard $ not $ P.null $ id3title id3 -- title sometimes empty
     pure id3
 
+-- Format: title (30), author (30), album (30), year (4), comment (30), genre
+-- We currently only use the first three.
 parseId3 :: ByteString -> Id3
 parseId3 = toId . cut where
     cut f | P.null f = []

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -67,54 +67,31 @@ doS s = do
 -- Track info if ID fields are in the file, otherwise file name.
 -- 30 chars per field?
 doI :: ByteString -> Msg
-doI s = let f = trim s
-        in case P.take 4 f of
-            cs | cs == "ID3:" -> F . File $
-                    let ttl = toId id3 . splitUp . P.drop 4 $ f
-                    -- mpg123 sometimes returns null titles
-                    in if P.null (id3title ttl) then Left f else Right ttl
-               | otherwise    -> F . File . Left $ f
-    where
-        -- a default
-        id3 :: Id3
-        id3 = Id3 "" "" "" ""
+doI s = let f = trim s in F . File $
+    if "ID3:" `P.isPrefixOf` f
+        then let ttl = toId . splitUp . P.drop 4 $ f
+            -- mpg123 sometimes returns null titles
+            in if P.null (id3title ttl) then Left f else Right ttl
+        else Left f
+  where
+    splitUp :: ByteString -> [ByteString]
+    splitUp f | P.null f = []
+              | True     = let (a, xs) = P.splitAt 30 f in a : splitUp xs
 
-        -- break the ID3 string up
-        splitUp :: ByteString -> [ByteString]
-        splitUp f
-            | f == P.empty  = []
-            | otherwise
-            = let (a,xs) = P.splitAt 30 f   -- we expect it to be 
-                  xs'    = splitUp xs
-              in a : xs'
+    toId :: [ByteString] -> Id3
+    toId ls = Id3 (arg 0) (arg 1) (arg 2) $ mconcat $ intersperse " : "
+        $ filter (not . P.null) [arg 1, arg 2, arg 0]
+      where
+        ls' = map normalise ls
+        arg = fromMaybe "" . (ls' !?)
 
-        -- and some ugly code:
-        toId :: Id3 -> [ByteString] -> Id3
-        toId i ls =
-            let arg n = normalise $ ls !! n
-                j = case length ls of
-                    0   -> i
-
-                    1   -> i { id3title  = arg 0 }
-
-                    2   -> i { id3title  = arg 0
-                             , id3artist = arg 1 }
-
-                    _   -> i { id3title  = arg 0
-                             , id3artist = arg 1
-                             , id3album  = arg 2 }
-
-            in j { id3str =
-                    mconcat $ intersperse " : " $ filter (not . P.null)
-                        [id3artist j, id3album j, id3title j] }
-
-        -- strip spaces, and decide if UTF-8 or ISO-8859-1
-        normalise :: ByteString -> ByteString
-        normalise raw =
-            let bs = trim raw
-            in if UTF8.replacement_char `elem` UTF8.toString bs
-                then UTF8.fromString $ P.unpack bs
-                else bs
+-- strip spaces, and if ISO-8859-1 convert to UTF-8
+normalise :: ByteString -> ByteString
+normalise raw =
+    let bs = trim raw
+    in if UTF8.replacement_char `elem` UTF8.toString bs
+        then UTF8.fromString $ P.unpack bs
+        else bs
 
 ------------------------------------------------------------------------
 
@@ -128,9 +105,11 @@ mpgParser line = do
         at : code : sp : _ = P.unpack pre
     when (at /= '@' || sp /= ' ') skip
 
-    -- TODO: make doX functions total
+    -- little helpers
     let errM = maybe (Left $ Just $ code : " parse error") Right
     let errE = first (fmap $ const $ code : " parse error")
+
+    -- TODO: make doX functions total
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -9,7 +9,7 @@
 module Lexer ( mpgParser, doP, doF, doS, doI, trim ) where
 
 import Base
-import Syntax (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
+import Syntax (Msg(..), Status(..), Frame(..), Info(..), Id3(..), File(..), Tag(..))
 
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
@@ -69,23 +69,19 @@ doS s = do
 -- Track info if ID fields are in the file, otherwise file name.
 -- 30 chars per field?
 doI :: ByteString -> Msg
-doI s = let f = trim s in F . File $
-    if "ID3:" `P.isPrefixOf` f
-        then let ttl = toId . splitUp . P.drop 4 $ f
-            -- mpg123 sometimes returns null titles
-            in if P.null (id3title ttl) then Left f else Right ttl
-        else Left f
-  where
-    splitUp :: ByteString -> [ByteString]
-    splitUp f | P.null f = []
-              | True     = let (a, xs) = P.splitAt 30 f in a : splitUp xs
+doI s = let s' = trim s in F $ File $ maybe (Left s') pure do
+    ("ID3:", info) <- pure $ P.splitAt 4 s'
+    let id3 = parseId3 info
+    guard $ not $ P.null $ id3title id3 -- title sometimes empty
+    pure id3
 
-    toId :: [ByteString] -> Id3
+parseId3 :: ByteString -> Id3
+parseId3 = toId . cut where
+    cut f | P.null f = []
+          | True     = let (a, xs) = P.splitAt 30 f in normalise a : cut xs
     toId ls = Id3 (arg 0) (arg 1) (arg 2) $ mconcat $ intersperse " : "
         $ filter (not . P.null) [arg 1, arg 2, arg 0]
-      where
-        ls' = map normalise ls
-        arg = fromMaybe "" . (ls' !?)
+      where arg = fromMaybe "" . (ls !?)
 
 -- strip spaces, and if ISO-8859-1 convert to UTF-8
 normalise :: ByteString -> ByteString

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-
 -- Copyright (c) 2005-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2008, 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
@@ -83,7 +81,7 @@ parseId3 = toId . cut where
         $ filter (not . P.null) [arg 1, arg 2, arg 0]
       where arg = fromMaybe "" . (ls !?)
 
--- strip spaces, and if ISO-8859-1 convert to UTF-8
+-- | Strip spaces, and if seeming ISO-8859-1 convert to UTF-8
 normalise :: ByteString -> ByteString
 normalise raw =
     let bs = trim raw
@@ -97,14 +95,13 @@ normalise raw =
 mpgParser :: ByteString -> Either (Maybe String) Msg
 mpgParser line = do
     -- bad packets are generally just \n in ID3 (and not of interest anyway)
-    let skip = Left Nothing
+    let quiet = maybe (Left Nothing) pure
 
-    when (P.length line < 3) skip
-    let (pre, m) = P.splitAt 3 line
-        at : code : sp : _ = P.unpack pre
-    when (at /= '@' || sp /= ' ') skip
+    code <- quiet do
+        '@' : c : ' ' : _ <- pure $ P.unpack line
+        pure c
 
-    let quiet = maybe skip pure
+    let m = P.drop 3 line
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m
@@ -112,5 +109,5 @@ mpgParser line = do
         'F' -> quiet $ doF m
         'P' -> quiet $ doP m
         'E' -> Left $ Just $ P.unpack m
-        _   -> skip
+        _   -> quiet Nothing
 

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -41,7 +41,20 @@ doF s = do
     timeLeft     <- max 0 <$> readMaybe (P.unpack f3)
     pure $ R Frame { currentFrame , framesLeft, currentTime, timeLeft }
 
--- Outputs information about the mp3 file after loading.
+-- Info about mp3 file after loading.
+-- Breakdown from mpg123 README.remote (as numbers):
+--   0 = mpeg type (string)
+--   1 = layer (int)
+--   2 = sampling frequency (int)
+--   3 = mode (string)
+--   4 = mode extension (int)
+--   5 = framesize (int)
+--   6 = stereo (int)
+--   7 = copyright (int)
+--   8 = error protection (int)
+--   9 = emphasis (int)
+--  10 = bitrate (int)
+--  11 = extension (int)
 doS :: ByteString -> Maybe Msg
 doS s = do
     let fs = P.split ' ' s

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -7,7 +7,7 @@
 module Lexer ( mpgParser, doP, doF, doS, doI, trim ) where
 
 import Base
-import Syntax (Msg(..), Status(..), Frame(..), Info(..), Id3(..), File(..), Tag(..))
+import Syntax (Msg(..), Status(..), Frame(..), Info(..), Id3(..), Tag(..))
 
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
@@ -65,10 +65,9 @@ doS s = do
             P.pack $ show $ hz `div` 1000, "kHz"]
 
 -- Track info if ID fields are in the file, otherwise file name.
--- 30 chars per field?
-doI :: ByteString -> Msg
-doI s = let s' = trim s in F $ File $ maybe (Left s') pure do
-    ("ID3:", info) <- pure $ P.splitAt 4 s'
+doI :: ByteString -> Maybe Msg
+doI s = F <$> do
+    ("ID3:", info) <- pure $ P.splitAt 4 s
     let id3 = parseId3 info
     guard $ not $ P.null $ id3title id3 -- title sometimes empty
     pure id3
@@ -104,7 +103,7 @@ mpgParser line = do
     let m = P.drop 3 line
     case code of
         'R' -> pure $ T Tag
-        'I' -> pure $ doI m
+        'I' -> quiet $ doI m
         'S' -> quiet $ doS m
         'F' -> quiet $ doF m
         'P' -> quiet $ doP m

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -20,8 +20,8 @@ import qualified Data.ByteString.UTF8 as UTF8
 trim :: ByteString -> ByteString
 trim = P.dropWhileEnd isSpace . P.dropSpace
 
-readPS :: ByteString -> Int
-readPS = fst . fromJust . P.readInt
+readPS :: ByteString -> Maybe Int
+readPS = fmap fst . P.readInt
 
 doP :: ByteString -> Either (Maybe ()) Msg
 doP s = case fst <$> P.uncons s of
@@ -35,40 +35,21 @@ doP s = case fst <$> P.uncons s of
 doF :: ByteString -> Maybe Msg
 doF s = do
     f0 : f1 : f2 : f3 : _ <- pure $ P.split ' ' s
-    pure $ R Frame
-        { currentFrame = readPS f0
-        , framesLeft   = readPS f1
-        , currentTime  = read . P.unpack $ f2
-        , timeLeft     = max 0 . read . P.unpack $ f3
-        }
+    currentFrame <- readPS f0
+    framesLeft   <- readPS f1
+    currentTime  <- readMaybe $ P.unpack f2
+    timeLeft     <- max 0 <$> readMaybe (P.unpack f3)
+    pure $ R Frame { currentFrame , framesLeft, currentTime, timeLeft }
 
 -- Outputs information about the mp3 file after loading.
-doS :: ByteString -> Msg
-doS s = let fs = P.split ' ' s
-        in I Info {
-            {-
-                  version       = fs !! 0
-                , layer         = read . P.unpack $ fs !! 1
-                , sampleRate    = read . P.unpack $ fs !! 2
-                , playMode      = fs !! 3
-                , modeExtns     = read . P.unpack $ fs !! 4
-                , bytesPerFrame = read . P.unpack $ fs !! 5
-                , channelCount  = read . P.unpack $ fs !! 6
-                , copyrighted   = toEnum (read $ P.unpack (fs !! 7))
-                , checksummed   = toEnum (read $ P.unpack (fs !! 8))
-                , emphasis      = read $ P.unpack $ fs !! 9
-                , bitrate       = read $ P.unpack $ fs !! 10
-                , extension     = read $ P.unpack $ fs !! 11
-            -}
-                userinfo      = mconcat
-                       ["mpeg "
-                       ,fs !! 0
-                       ," "
-                       ,fs !! 10
-                       ,"kbit/s "
-                       ,(P.pack . show) (readPS (fs !! 2) `div` 1000 :: Int)
-                       ,"kHz"]
-                }
+doS :: ByteString -> Maybe Msg
+doS s = do
+    let fs = P.split ' ' s
+    guard $ length fs >= 11
+    hz <- readPS $ fs !! 2
+    pure . I . Info $ mconcat [
+        "mpeg ", fs !! 0, " ", fs !! 10, "kbit/s ",
+            (P.pack . show) (hz `div` 1000 :: Int), "kHz"]
 
 -- Track info if ID fields are in the file, otherwise file name.
 -- 30 chars per field?
@@ -140,7 +121,7 @@ mpgParser line = do
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m
-        'S' -> pure $ doS m
+        'S' -> errM $ doS m
         'F' -> errM $ doF m
         'P' -> errE $ doP m
         'E' -> Left $ Just $ P.unpack m

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -13,7 +13,6 @@ import Syntax (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
 
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
-import Control.Monad.Except
 
 ------------------------------------------------------------------------
 
@@ -24,27 +23,24 @@ trim = P.dropWhileEnd isSpace . P.dropSpace
 readPS :: ByteString -> Int
 readPS = fst . fromJust . P.readInt
 
-doP :: ByteString -> Msg
-doP s = S case fst <$> P.uncons s of
-    Just '0' -> Stopped
-    Just '1' -> Paused
-    Just '2' -> Playing
-    -- mpg123 outputs this but then @P 0 causing double Plays
-    -- (I think old mpg123 didn't do @P 0 so I added this)
-    -- '3' -> Stopped  -- used by mpg123 for end of song
-    _ -> Playing
-    -- _ -> error "Invalid Status"
+doP :: ByteString -> Either (Maybe ()) Msg
+doP s = case fst <$> P.uncons s of
+    Just '0' -> Right $ S Stopped
+    Just '1' -> Right $ S Paused
+    Just '2' -> Right $ S Playing
+    Just '3' -> Left Nothing -- newer mpg123 outputs for end of song; don't need
+    _        -> Left (Just ())
 
 -- Frame decoding status updates (once per frame).
-doF :: ByteString -> Msg
-doF s = R Frame {
-                currentFrame = readPS f0
-              , framesLeft   = readPS f1
-              , currentTime  = read . P.unpack $ f2
-              , timeLeft     = max 0 . read . P.unpack $ f3
-           }
-        where
-          f0 : f1 : f2 : f3 : _ = P.split ' ' s
+doF :: ByteString -> Maybe Msg
+doF s = do
+    f0 : f1 : f2 : f3 : _ <- pure $ P.split ' ' s
+    pure $ R Frame
+        { currentFrame = readPS f0
+        , framesLeft   = readPS f1
+        , currentTime  = read . P.unpack $ f2
+        , timeLeft     = max 0 . read . P.unpack $ f3
+        }
 
 -- Outputs information about the mp3 file after loading.
 doS :: ByteString -> Msg
@@ -128,7 +124,7 @@ doI s = let f = trim s
 
 ------------------------------------------------------------------------
 
-mpgParser :: ByteString -> Either (Maybe ByteString) Msg
+mpgParser :: ByteString -> Either (Maybe String) Msg
 mpgParser line = do
     -- bad packets are generally just \n in ID3 (and not of interest anyway)
     let skip = Left Nothing
@@ -139,12 +135,14 @@ mpgParser line = do
     when (at /= '@' || sp /= ' ') skip
 
     -- TODO: make doX functions total
+    let errM = maybe (Left $ Just $ code : " parse error") Right
+    let errE = first (fmap $ const $ code : " parse error")
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m
         'S' -> pure $ doS m
-        'F' -> pure $ doF m
-        'P' -> pure $ doP m
-        'E' -> Left $ Just m
+        'F' -> errM $ doF m
+        'P' -> errE $ doP m
+        'E' -> Left $ Just $ P.unpack m
         _   -> skip
 

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -60,9 +60,9 @@ doS s = do
     let fs = P.split ' ' s
     guard $ length fs >= 11
     hz <- readPS $ fs !! 2
-    pure . I . Info $ mconcat [
+    pure $ I $ Info $ mconcat [
         "mpeg ", fs !! 0, " ", fs !! 10, "kbit/s ",
-            (P.pack . show) (hz `div` 1000 :: Int), "kHz"]
+            P.pack $ show $ hz `div` 1000, "kHz"]
 
 -- Track info if ID fields are in the file, otherwise file name.
 -- 30 chars per field?
@@ -106,10 +106,9 @@ mpgParser line = do
     when (at /= '@' || sp /= ' ') skip
 
     -- little helpers
-    let errM = maybe (Left $ Just $ code : " parse error") Right
     let errE = first (fmap $ const $ code : " parse error")
+    let errM = errE . maybe (Left $ Just ()) Right
 
-    -- TODO: make doX functions total
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -6,7 +6,7 @@
 
 -- Lexer for mpg123 messages
 
-module Lexer ( parser, doP, doF, doS, doI, trim ) where
+module Lexer ( mpgParser, doP, doF, doS, doI, trim ) where
 
 import Base
 import Syntax (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
@@ -14,7 +14,6 @@ import Syntax (Msg(..),Status(..),Frame(..),Info(..),Id3(..),File(..),Tag(..))
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
 import Control.Monad.Except
-import Control.Monad.Trans (lift)
 
 ------------------------------------------------------------------------
 
@@ -129,14 +128,13 @@ doI s = let f = trim s
 
 ------------------------------------------------------------------------
 
-parser :: Handle -> IO (Either (Maybe String) Msg)
-parser h = runExceptT do
-    x <- lift $ P.hGetLine h
+mpgParser :: ByteString -> Either (Maybe ByteString) Msg
+mpgParser line = do
     -- bad packets are generally just \n in ID3 (and not of interest anyway)
-    let skip = throwError Nothing
+    let skip = Left Nothing
 
-    when (P.length x < 3) skip
-    let (pre, m) = P.splitAt 3 x
+    when (P.length line < 3) skip
+    let (pre, m) = P.splitAt 3 line
         at : code : sp : _ = P.unpack pre
     when (at /= '@' || sp /= ' ') skip
 
@@ -147,6 +145,6 @@ parser h = runExceptT do
         'S' -> pure $ doS m
         'F' -> pure $ doF m
         'P' -> pure $ doP m
-        'E' -> throwError $ Just $ "mpg123 error: " ++ P.unpack m
+        'E' -> Left $ Just m
         _   -> skip
 

--- a/Lexer.hs
+++ b/Lexer.hs
@@ -23,13 +23,15 @@ trim = P.dropWhileEnd isSpace . P.dropSpace
 readPS :: ByteString -> Maybe Int
 readPS = fmap fst . P.readInt
 
-doP :: ByteString -> Either (Maybe ()) Msg
-doP s = case fst <$> P.uncons s of
-    Just '0' -> Right $ S Stopped
-    Just '1' -> Right $ S Paused
-    Just '2' -> Right $ S Playing
-    Just '3' -> Left Nothing -- newer mpg123 outputs for end of song; don't need
-    _        -> Left (Just ())
+doP :: ByteString -> Maybe Msg
+doP s = do
+    (p, _) <- P.uncons s
+    case p of
+        '0' -> pure $ S Stopped
+        '1' -> pure $ S Paused
+        '2' -> pure $ S Playing
+        -- recent mpg123 outputs 3 for end of song; don't need
+        _   -> Nothing
 
 -- Frame decoding status updates (once per frame).
 doF :: ByteString -> Maybe Msg
@@ -95,6 +97,7 @@ normalise raw =
 
 ------------------------------------------------------------------------
 
+-- Parse line; on failure, return Just only if error to report.
 mpgParser :: ByteString -> Either (Maybe String) Msg
 mpgParser line = do
     -- bad packets are generally just \n in ID3 (and not of interest anyway)
@@ -105,16 +108,13 @@ mpgParser line = do
         at : code : sp : _ = P.unpack pre
     when (at /= '@' || sp /= ' ') skip
 
-    -- little helpers
-    let errE = first (fmap $ const $ code : " parse error")
-    let errM = errE . maybe (Left $ Just ()) Right
-
+    let quiet = maybe skip pure
     case code of
         'R' -> pure $ T Tag
         'I' -> pure $ doI m
-        'S' -> errM $ doS m
-        'F' -> errM $ doF m
-        'P' -> errE $ doP m
+        'S' -> quiet $ doS m
+        'F' -> quiet $ doF m
+        'P' -> quiet $ doP m
         'E' -> Left $ Just $ P.unpack m
         _   -> skip
 

--- a/Syntax.hs
+++ b/Syntax.hs
@@ -69,40 +69,10 @@ data Id3 = Id3
 --      , genre  :: Maybe ByteString }
 
 
-
--- Outputs information about the mp3 file after loading.
--- <a>: version of the mp3 file. Currently always 1.0 with madlib, but don't 
---      depend on it, particularly if you intend portability to mpg123 as well.
---      Float/string.
--- <b>: layer: 1, 2, or 3. Integer.
--- <c>: Samplerate. Integer.
--- <d>: Mode string. String.
--- <e>: Mode extension. Integer.
--- <f>: Bytes per frame (estimate, particularly if the stream is VBR). Integer.
--- <g>: Number of channels (1 or 2, usually). Integer.
--- <h>: Is stream copyrighted? (1 or 0). Integer.
--- <i>: Is stream CRC protected? (1 or 0). Integer.
--- <j>: Emphasis. Integer.
--- <k>: Bitrate, in kbps. (i.e., 128.) Integer.
--- <l>: Extension. Integer.
-newtype Info = Info {
-                userinfo      :: ByteString  -- user friendly string
-           --   version       :: !ByteString,
-           --   layer         :: !Int,     -- 1,2 or 3
-           --   sampleRate    :: !Int,
-           --   playMode      :: !ByteString,
-           --   modeExtns     :: !Int,
-           --   bytesPerFrame :: !Int,
-           --   channelCount  :: !Int,
-           --   copyrighted   :: !Bool,
-           --   checksummed   :: !Bool,
-           --   emphasis      :: !Int,
-           --   bitrate       :: !Int,
-           --   extension     :: !Int
-            }
+-- mp3 file info; TODO maybe don't need this newtype at all?
+newtype Info = Info { userinfo :: ByteString }
     deriving stock (Eq, Show)
 
--- @F <current-frame> <frames-remaining> <current-time> <time-remaining>
 -- Frame decoding status updates (once per frame).
 -- Current-frame and frames-remaining are integers; current-time and
 -- time-remaining floating point numbers with two decimal places.
@@ -114,14 +84,8 @@ data Frame = Frame {
              }
     deriving stock (Eq, Show)
 
--- @P {0, 1, 2}
 -- Stop/pause status.
--- 0 - playing has stopped. When 'STOP' is entered, or the mp3 file is finished.
--- 1 - Playing is paused. Enter 'PAUSE' or 'P' to continue.
--- 2 - Playing has begun again.
-data Status = Stopped
-            | Paused
-            | Playing
+data Status = Stopped | Paused | Playing
     deriving stock (Eq, Show)
 
 data Mode = Once | Loop | Random | Single

--- a/Syntax.hs
+++ b/Syntax.hs
@@ -52,10 +52,6 @@ instance Pretty Quit where
 data Tag = Tag
     deriving stock (Eq, Show)
 
--- Track info if ID fields are in the file, otherwise file name.
-newtype File = File (Either ByteString Id3)
-    deriving stock (Eq, Show)
-
 -- ID3 info
 data Id3 = Id3
         { id3title  :: !ByteString
@@ -103,7 +99,7 @@ class Pretty a where
 -- And a wrapper type 
 --
 data Msg = T {-# UNPACK #-} !Tag
-         | F                !File
+         | F                !Id3
          | I {-# UNPACK #-} !Info
          | R {-# UNPACK #-} !Frame
          | S                !Status

--- a/UI.hs
+++ b/UI.hs
@@ -576,9 +576,6 @@ slice i j arr =
     in [unsafeAt arr n | n <- [max a i .. min b j] ]
 {-# INLINE slice #-}
 
--- isAscii :: ByteString -> Bool
--- isAscii = P.all (<'\128')
-
 ------------------------------------------------------------------------
 
 --
@@ -598,9 +595,7 @@ setXtermTitle strs = do
 setXterm :: HState -> IO ()
 setXterm s = setXtermTitle $ case status s of
     Playing -> case id3 s of
-        Nothing -> case size s of
-                        0 -> ["hmp3"]
-                        _ -> [fbase $ music s ! current s]
+        Nothing -> [fbase $ music s ! current s]
         Just ti -> id3artist ti :
                    if P.null (id3title ti)
                         then []

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -4,9 +4,16 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import qualified Data.ByteString.Char8 as P
+import Data.Foldable (toList)
 
-import Lexer (doP, doF, doS, doI, trim)
+import qualified Lexer as L
 import Syntax
+
+doI = L.doI
+trim = L.trim
+doF = head . toList . L.doF
+doP = head . toList . L.doP
+doS = head . toList . L.doS
 
 tests :: TestTree
 tests = testGroup "Lexer"
@@ -14,9 +21,9 @@ tests = testGroup "Lexer"
         [ testCase "0 is Stopped"        $ doP "0"   @?= S Stopped
         , testCase "1 is Paused"         $ doP "1"   @?= S Paused
         , testCase "2 is Playing"        $ doP "2"   @?= S Playing
-        , testCase "3 is Playing"        $ doP "3"   @?= S Playing
-        , testCase "empty is Playing"    $ doP ""    @?= S Playing
-        , testCase "garbage is Playing"  $ doP "xyz" @?= S Playing
+        -- , testCase "3 is Playing"        $ doP "3"   @?= S Playing
+        -- , testCase "empty is Playing"    $ doP ""    @?= S Playing
+        -- , testCase "garbage is Playing"  $ doP "xyz" @?= S Playing
         ]
     , testGroup "doF (frame messages)"
         [ testCase "all four fields parse" $
@@ -62,3 +69,4 @@ tests = testGroup "Lexer"
 -- matching the fixed-width field convention used by mpg123 ID3 output.
 field30 :: P.ByteString -> P.ByteString
 field30 b = P.take 30 (b <> P.replicate 30 ' ')
+

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-x-partial -Wno-missing-signatures #-} -- XXX
+
 module LexerSpec (tests) where
 
 import Test.Tasty

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -9,7 +9,7 @@ import Data.Foldable (toList)
 import qualified Lexer as L
 import Syntax
 
--- Emulate old API for tests
+-- Emulate old API for tests (XXX temporary)
 doI = L.doI
 trim = L.trim
 doF = head . toList . L.doF

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -42,24 +42,24 @@ tests = testGroup "Lexer"
     , testGroup "doI (track info / id3)"
         [ testCase "non-id3 input becomes Left filename" $
             doI "song.mp3"
-                @?= F (File (Left "song.mp3"))
+                @?= Nothing
         , testCase "non-id3 input is trimmed" $
             doI "  song.mp3  "
-                @?= F (File (Left "song.mp3"))
+                @?= Nothing
         , testCase "id3 with title only" $
             doI ("ID3:" <> field30 "Title")
-                @?= F (File (Right (Id3 "Title" "" "" "Title")))
+                @?= Just (F (Id3 "Title" "" "" "Title"))
         , testCase "id3 with title and artist" $
             doI ("ID3:" <> field30 "Title" <> field30 "Artist")
-                @?= F (File (Right (Id3 "Title" "Artist" "" "Artist : Title")))
+                @?= Just (F (Id3 "Title" "Artist" "" "Artist : Title"))
         , testCase "id3 with title, artist, and album" $
             doI ("ID3:" <> field30 "Title" <> field30 "Artist" <> field30 "Album")
-                @?= F (File (Right (Id3 "Title" "Artist" "Album" "Artist : Album : Title")))
+                @?= Just (F (Id3 "Title" "Artist" "Album" "Artist : Album : Title"))
         , testCase "id3 with empty title falls back to Left of trimmed input" $
             -- mpg123 sometimes returns ID3 records with a blank title; rather than
             -- present an empty track name, the parser exposes the raw line.
             doI ("ID3:" <> field30 "" <> field30 "Artist")
-                @?= F (File (Left ("ID3:" <> P.replicate 30 ' ' <> "Artist")))
+                @?= Nothing
         ]
     , testGroup "trim"
         [ testCase "whitespace on ends" $ trim " \t foo bar \n " @?= "foo bar"

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -9,6 +9,7 @@ import Data.Foldable (toList)
 import qualified Lexer as L
 import Syntax
 
+-- Emulate old API for tests
 doI = L.doI
 trim = L.trim
 doF = head . toList . L.doF


### PR DESCRIPTION
The partiality of the helper functions in `Lexer.hs` was noted by me as a TODO back in 2019, and flagged again in a Claude Code review only recently.  While invalid output from `mpg123` would not be expected, there are theoretical ways for it to occur (newlines in ID3 data, though maybe mpg123 today addresses that), mpg123 itself might change its protocol in ways that cause unexpected breakage (for example, it did, see below), Haskell these days favors totality, and it's easy enough to add it.  Thus, this PR converts most `do*` functions to return `Maybe`s.

In addition,

*  Lexer functions are now all pure.  This separates concerns of the pipe reading and the parsing, whereas previously it wasn't clear the only I/O in `parser` (now `mpgParser`) was pulling in one line.
*  The outer `trim` in `doI` is apparently wrong.  Spacing is checked to not be added after `ID3:`, so any space there would be an initial space in the title.  Not expected, but if it happens, then trimming will shift the other columns over, causing wrong slicing.  (Possibly this is for `mpg321` compatibility?  Well, if so, we're dropping its support soon anyway.)
*  The `File` newtype was an Either underneath, but despite careful population of the Left side with a filename fallback, the Left payload was never actually used.  So it could as well be a `Maybe`.  In fact, per next point, it can be a plain `Id3`.  So I got rid of the newtype entirely, which I already disliked for the name clash with `Tree.File`.
*  Current versions of mpg123 can output multiple `@I` lines.  The existing code appears to assume only one, and if it's not `ID3:`, then an `F` event erases the ID3 information.  Thus, the last of the `@I` lines is controlling.  This produced less frequent ID3 parsing for a while, but more recent versions of mpg123 add `@I {` and `@I }` lines to enclose these lines, "to guide parsers" (from the README), so in fact ID3 data is now _always_ overwritten with Nothing.  I suppose I half-noticed that I was seeing this info less and less over time, and now I understand it is gone completely.  This is half-fixed in this PR by not generating an `F` `Msg` at all if it's not an `ID3:` line, so data is not overwritten.  To prevent bleed from the previous track in cases where there is no such line (that is, no ID3 info, so the `@I` line is only the filename), I have `runPlayOp` set the field to Nothing on a new track.  Maybe a hack, and there are certainly imperfections:
    *  There is a sometimes noticeable "flicker" as the filename is shown in the top and terminal title before the `@I` lines get read in.  This existed before, but (IIUC) only when a non-ID3 song was followed by an ID3 song; now it's any ID3 song regardless of predecessor.  I couldn't find a simple trick to prevent this.  This is technically a regression from previous behavior, but it's small enough that I'm not going to hold up this fix over it.  I'll write up an issue.
    *  More broadly, this new ID3 data is useful.  The v2 fields for title/author/etc. don't have a cut-off at 30 characters, which is often exceeded, with unsightly results.  So there is an opportunity to improve the app with a more sophisticated parser.  That may be folded into the aforementioned issue.
*  Tests have been hacked to still test and pass.  I will have Claude Code redo them correctly.
*  Comments are made up to date and more useful for development.  For instance, I at some point might decide to change what song metadata to display.
*  Minor other clean-up.