### PR TITLE
General code maintenance and some rearrangement.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: 'ubuntu-22.04'
     strategy:
       matrix:
-        ghc: ['9.6', '9.8', '9.10', 'latest']
+        ghc: ['9.0.1', '9.10', '9.12', 'latest']
     name: GHC ${{ matrix.ghc }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -18,8 +18,9 @@ jobs:
     runs-on: 'ubuntu-22.04'
     name: Stack
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
       - run: stack test
+

--- a/Base.hs
+++ b/Base.hs
@@ -24,6 +24,7 @@ import Data.Maybe as X
 import Data.String as X
 import Data.Traversable as X
 import Data.Version as X
+import Data.Void as X
 import Data.Word as X
 import System.Exit as X
 import System.IO as X (Handle, hClose)

--- a/Core.hs
+++ b/Core.hs
@@ -262,6 +262,8 @@ mpgInput field = runForever $ do
 ------------------------------------------------------------------------
 
 -- | Close most things. Important to do all the jobs:
+-- TODO maybe releaseSignals here in case mpg is frozen?
+--   and/or move UI.end up?
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
     silentlyModifyHS $ \st -> st { exiting = True }

--- a/Core.hs
+++ b/Core.hs
@@ -264,7 +264,7 @@ mpgInput field = runForever $ do
 -- | Close most things. Important to do all the jobs:
 -- TODO maybe releaseSignals here in case mpg is frozen?
 --   and/or move UI.end up?
-shutdown :: Maybe String -> IO ()
+shutdown :: Maybe String -> IO a
 shutdown ms = do
     silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState
@@ -577,7 +577,7 @@ getConfPath = getXdgDirectory XdgConfig $ "hmp3" </> "style.conf"
 
 loadConfig :: IO ()
 loadConfig = do
-    f <- fromMaybe <$> getConfPath <*> getsHS configPath
+    f <- maybe getConfPath pure =<< getsHS configPath
     b <- doesFileExist f
     if b then do
         str' <- readFile f

--- a/Core.hs
+++ b/Core.hs
@@ -264,7 +264,7 @@ mpgInput field = runForever $ do
 -- | Close most things. Important to do all the jobs:
 -- TODO maybe releaseSignals here in case mpg is frozen?
 --   and/or move UI.end up?
-shutdown :: Maybe String -> IO a
+shutdown :: Maybe String -> IO ()
 shutdown ms = do
     silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState

--- a/Core.hs
+++ b/Core.hs
@@ -9,7 +9,7 @@
 --
 module Core (
     Options(..),
-    initialize, shutdown,
+    start, shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
     forcePause, putMessage, clearMessage, playCursor, playCur,
     jumpToPlaying, jump, jumpRel,
@@ -72,8 +72,8 @@ data Options = Options
     }
 
 -- | Sets up state, spawns sub-threads, and starts player.
-initialize :: Options -> Tree -> IO ()
-initialize opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
+start :: Options -> Tree -> IO ()
+start opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
 
     config <- UI.start
     bootTime <- getMonoTime

--- a/Core.hs
+++ b/Core.hs
@@ -73,7 +73,7 @@ data Options = Options
 
 -- | Sets up state, spawns sub-threads, and starts player.
 start :: Options -> Tree -> IO ()
-start opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
+start opts (Tree folders music) = do
 
     config <- UI.start
     bootTime <- getMonoTime

--- a/Core.hs
+++ b/Core.hs
@@ -9,8 +9,7 @@
 --
 module Core (
     Options(..),
-    start,
-    shutdown,
+    initialize, shutdown,
     seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
     forcePause, putMessage, clearMessage, playCursor, playCur,
     jumpToPlaying, jump, jumpRel,
@@ -35,9 +34,6 @@ import Tree hiding (File, Dir)
 import qualified Tree (File,Dir)
 import qualified UI
 
-import Text.Regex.PCRE.Light
-import {-# SOURCE #-} Keymap (keyLoop)
-
 import qualified Data.ByteString.Char8 as P
 import qualified Data.Sequence as Seq
 
@@ -56,6 +52,8 @@ import System.Posix.FilePath    (takeFileName)
 
 import System.Posix.Process     (exitImmediately)
 
+import Text.Regex.PCRE.Light
+
 
 mp3Tool :: String
 mp3Tool =
@@ -73,8 +71,9 @@ data Options = Options
     , optConfigPath :: !(Maybe FilePath) -- ^ override the style.conf location
     }
 
-start :: Options -> Tree -> IO ()
-start opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
+-- | Sets up state, spawns sub-threads, and starts player.
+initialize :: Options -> Tree -> IO ()
+initialize opts (Tree folders music) = handle @SomeException (shutdown . Just . show) do
 
     config <- UI.start
     bootTime <- getMonoTime
@@ -127,8 +126,6 @@ start opts (Tree folders music) = handle @SomeException (shutdown . Just . show)
 
     playCur
     when (optPaused opts) pause -- TODO use LOADPAUSED?
-
-    run         -- won't restart if this fails!
 
 ------------------------------------------------------------------------
 
@@ -261,12 +258,6 @@ mpgInput field = runForever $ do
         Right m       -> handleMsg m
         Left (Just e) -> warnA ("mpg123: " ++ e)
         _             -> pure ()
-
-------------------------------------------------------------------------
-
--- | The main thread: handle keystrokes fed to us by curses
-run :: IO ()
-run = runForever keyLoop
 
 ------------------------------------------------------------------------
 
@@ -584,7 +575,7 @@ getConfPath = getXdgDirectory XdgConfig $ "hmp3" </> "style.conf"
 
 loadConfig :: IO ()
 loadConfig = do
-    f <- maybe getConfPath pure =<< getsHS configPath
+    f <- fromMaybe <$> getConfPath <*> getsHS configPath
     b <- doesFileExist f
     if b then do
         str' <- readFile f

--- a/Keyboard.hs
+++ b/Keyboard.hs
@@ -1,6 +1,6 @@
-{-# OPTIONS -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
--- Copyright (c) 2019-2026 Galen Huntington
+-- Copyright (c) 2019, 2023-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
 module Keyboard (unkey, charToKey, Key(..)) where

--- a/Keyboard.hs
+++ b/Keyboard.hs
@@ -1,0 +1,31 @@
+{-# OPTIONS -Wno-orphans #-}
+
+-- Copyright (c) 2019-2026 Galen Huntington
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+module Keyboard (unkey, charToKey, Key(..)) where
+
+import Base
+
+import qualified Data.Map.Strict as M
+import UI.HSCurses.Curses (Key(..), decodeKey)
+
+------------------------------------------------------------------------
+-- Char ↔ Key translation
+--
+-- ncurses delivers special keys as integer codes ≥ 256; for everything
+-- in 0..255 'decodeKey' returns 'KeyChar (chr n)'.  We keep working in
+-- 'Char' (UI.getKey's type), so we extend the range up to '\500' to
+-- cover the named keys we actually use (KEY_RESIZE is around 410).
+
+deriving stock instance Ord Key
+
+charToKey :: Char -> Key
+charToKey = decodeKey . toEnum . fromEnum
+
+keyCharMap :: M.Map Key Char
+keyCharMap = M.fromList [(charToKey c, c) | c <- ['\0' .. '\500']]
+
+unkey :: Key -> Char
+unkey k = fromMaybe '\0' $ M.lookup k keyCharMap
+

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -39,7 +39,7 @@ newtype KeyMap = KeyMap (Char -> IO KeyMap)
 -- | Read keys forever and dispatch.  Each round clears the minibuffer
 -- between the keystroke and the action so messages from the previous
 -- action remain visible until the user reacts.
-keyLoop :: IO ()
+keyLoop :: IO Void
 keyLoop = go mainMode where
     go (KeyMap f) = UI.getKey >>= \c -> clearMessage *> f c >>= go
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS -Wno-orphans #-}
-
 -- Copyright (c) 2004-2008 Don Stewart - http://www.cse.unsw.edu.au/~dons
 -- Copyright (c) 2008, 2019-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
@@ -18,11 +16,10 @@ import Base
 
 import Core
 import Config (package)
+import Keyboard (unkey, charToKey, Key(..))
 import State (getsHS, modifyHS_, KeysHelp, Modal(..), HState(..))
 import Style (defaultSty, StringA(Fast))
 import qualified UI (getKey, resetui)
-
-import UI.HSCurses.Curses (Key(..), decodeKey)
 
 import qualified Data.ByteString.Char8 as P
 import qualified Data.ByteString.UTF8 as UTF8
@@ -131,26 +128,6 @@ zipUp   (Zipper c (nx:rest) f)  = Zipper nx rest (c:f)
 zipUp   z                       = z
 zipDown (Zipper c b (pv:rest))  = Zipper pv (c:b) rest
 zipDown z                       = z
-
-
-------------------------------------------------------------------------
--- Char ↔ Key translation
---
--- ncurses delivers special keys as integer codes ≥ 256; for everything
--- in 0..255 'decodeKey' returns 'KeyChar (chr n)'.  We keep working in
--- 'Char' (UI.getKey's type), so we extend the range up to '\500' to
--- cover the named keys we actually use (KEY_RESIZE is around 410).
-
-deriving stock instance Ord Key
-
-charToKey :: Char -> Key
-charToKey = decodeKey . toEnum . fromEnum
-
-keyCharMap :: M.Map Key Char
-keyCharMap = M.fromList [(charToKey c, c) | c <- ['\0' .. '\500']]
-
-unkey :: Key -> Char
-unkey k = fromMaybe '\0' $ M.lookup k keyCharMap
 
 enter', delete' :: [Char]
 enter'  = ['\n', '\r']

--- a/Keymap.hs-boot
+++ b/Keymap.hs-boot
@@ -2,8 +2,6 @@ module Keymap where
 
 import UI.HSCurses.Curses (Key)
 
-keyLoop :: IO ()
-
 unkey      :: Key -> Char
 charToKey  :: Char -> Key
 

--- a/Keymap.hs-boot
+++ b/Keymap.hs-boot
@@ -1,7 +1,0 @@
-module Keymap where
-
-import UI.HSCurses.Curses (Key)
-
-unkey      :: Key -> Char
-charToKey  :: Char -> Key
-

--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ versions, which were only minor changes, mostly the automated
 regeneration of a `configure` file (now gone).
 
 *  The code has been updated to compile under recent GHC (tested
-through 9.10) and libraries.  This required rewriting or entirely
-replacing large sections, mainly low-level optimizations.
+through 9.14; minimum supported 9.0) and libraries.  This required
+rewriting or entirely replacing large sections, mainly low-level
+optimizations.
 
 *  I added support for building with Stack.  It can also be installed
 with Nix from nixpkgs (`haskellPackages.hmp3-ng`).
 
 *  There is a public GitHub issue tracker, and a GitHub action to
 continuously test builds.
+
+*  There is a test suite built on the Tasty framework.
 
 *  I try to avoid “Not Invented Here” by using established,
 up-to-date packages from Hackage.  Much old code has now been

--- a/UI.hs
+++ b/UI.hs
@@ -27,7 +27,7 @@ import Syntax
 import Config
 import Width                    (displayWidth, toMaxWidth, toWidth)
 import qualified UI.HSCurses.Curses as Curses
-import {-# SOURCE #-} Keymap    (unkey, charToKey)
+import Keyboard                 (unkey, charToKey)
 
 import Data.Array               ((!), bounds, Array)
 import Data.Array.Base          (unsafeAt)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -72,11 +72,12 @@ parserInfo = info (invocation <**> versionOpt <**> helper) $
 main :: IO ()
 main = do
     (opts, args) <- customExecParser (prefs showHelpOnEmpty) parserInfo
-    initSignals
     tree <- buildTree args
     when (isEmpty tree) $
         errorWithoutStackTrace "Error: No music files found."
-    start opts tree
-    err <- either id absurd <$> try @SomeException keyLoop
-    shutdown $ Just $ "Input error: " ++ show err
+    initSignals
+    err <- either id absurd <$> try @SomeException do
+        start opts tree
+        keyLoop
+    shutdown $ Just $ "Error: " ++ show err
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,7 +7,7 @@ module Main where
 
 import Base
 
-import Core     (initialize, shutdown, Options(..))
+import Core     (start, shutdown, Options(..))
 import qualified Config
 import Keymap   (keyLoop)
 import Tree     (buildTree, isEmpty)
@@ -76,7 +76,7 @@ main = do
     tree <- buildTree args
     when (isEmpty tree) $
         errorWithoutStackTrace "Error: No music files found."
-    initialize opts tree
+    start opts tree
     err <- either id absurd <$> try @SomeException keyLoop
     shutdown $ Just $ "Input error: " ++ show err
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,8 +7,9 @@ module Main where
 
 import Base
 
-import Core     (start, shutdown, Options(..))
+import Core     (initialize, shutdown, Options(..))
 import qualified Config
+import Keymap   (keyLoop)
 import Tree     (buildTree, isEmpty)
 
 import System.IO            (hPrint, stderr)
@@ -73,7 +74,9 @@ main = do
     (opts, args) <- customExecParser (prefs showHelpOnEmpty) parserInfo
     initSignals
     tree <- buildTree args
-    if isEmpty tree
-        then putStrLn "Error: No music files found." *> exitFailure
-        else start opts tree -- never returns
+    when (isEmpty tree) $
+        errorWithoutStackTrace "Error: No music files found."
+    initialize opts tree
+    err <- either id absurd <$> try @SomeException keyLoop
+    shutdown $ Just $ "Input error: " ++ show err
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -15,8 +15,6 @@ maintainer: Galen Huntington
 license: GPL-2.0-or-later
 license-file: LICENSE
 build-type: Simple
-extra-source-files:
-  Keymap.hs-boot
 
 extra-doc-files:
   README.md

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -56,6 +56,7 @@ library
     Base
     Config
     Core
+    Keyboard
     Keymap
     Lexer
     State

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -1,23 +1,25 @@
 cabal-version: 3.0
+name: hmp3-ng
+version: 2.18.0
+synopsis: A 2019 fork of an ncurses mp3 player written in Haskell
+description:
+  An mp3 player with a curses frontend.  Playlists are populated by
+  passing file and directory names on the command line.  'h' displays
+  help.
 
-name:           hmp3-ng
-version:        2.18.0
-synopsis:       A 2019 fork of an ncurses mp3 player written in Haskell
-description:    An mp3 player with a curses frontend.  Playlists are populated by
-                passing file and directory names on the command line.  'h' displays
-                help.
-category:       Sound
-homepage:       https://github.com/galenhuntington/hmp3-ng#readme
-bug-reports:    https://github.com/galenhuntington/hmp3-ng/issues
-author:         Don Stewart, Galen Huntington
-maintainer:     Galen Huntington
-license:        GPL-2.0-or-later
-license-file:   LICENSE
-build-type:     Simple
+category: Sound
+homepage: https://github.com/galenhuntington/hmp3-ng#readme
+bug-reports: https://github.com/galenhuntington/hmp3-ng/issues
+author: Don Stewart, Galen Huntington
+maintainer: Galen Huntington
+license: GPL-2.0-or-later
+license-file: LICENSE
+build-type: Simple
 extra-source-files:
-    Keymap.hs-boot
+  Keymap.hs-boot
+
 extra-doc-files:
-    README.md
+  README.md
 
 source-repository head
   type: git
@@ -26,61 +28,68 @@ source-repository head
 common opts
   default-language: Haskell2010
   default-extensions:
-      BlockArguments
-      MultiWayIf
-      OverloadedStrings
-      RecordWildCards
-      -- In GHC2024
-      DerivingStrategies
-      LambdaCase
-      -- In GHC2021 (soon!)
-      BangPatterns
-      GeneralizedNewtypeDeriving
-      NamedFieldPuns
-      NumericUnderscores
-      ScopedTypeVariables
-      StandaloneDeriving
-      TupleSections
-      TypeApplications
-  ghc-options: -Wall -funbox-strict-fields
+    BlockArguments
+    MultiWayIf
+    OverloadedStrings
+    RecordWildCards
+    -- In GHC2024
+    DerivingStrategies
+    LambdaCase
+    -- In GHC2021 (soon!)
+    BangPatterns
+    GeneralizedNewtypeDeriving
+    NamedFieldPuns
+    NumericUnderscores
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+
+  ghc-options:
+    -Wall
+    -funbox-strict-fields
 
 library
   import: opts
   hs-source-dirs: ./
   exposed-modules:
-      Base
-      Config
-      Core
-      Keymap
-      Lexer
-      State
-      Style
-      Syntax
-      Tree
-      UI
-      Width
+    Base
+    Config
+    Core
+    Keymap
+    Lexer
+    State
+    Style
+    Syntax
+    Tree
+    UI
+    Width
+
   other-modules:
-      Paths_hmp3_ng
+    Paths_hmp3_ng
+
   autogen-modules:
-      Paths_hmp3_ng
+    Paths_hmp3_ng
+
   pkgconfig-depends:
-      ncursesw
+    ncursesw
+
   build-depends:
-    , array
-    , base >=4.15 <5
-    , bytestring >=0.10
-    , clock
-    , containers
-    , directory >=1.3.7.0
-    , filepath
-    , hscurses
-    , mtl
-    , pcre-light >=0.3
-    , posix-paths
-    , process
-    , random
-    , unix >=2.7
-    , utf8-string
+    array,
+    base >=4.15 && <5,
+    bytestring >=0.10,
+    clock,
+    containers,
+    directory >=1.3.7.0,
+    filepath,
+    hscurses,
+    mtl,
+    pcre-light >=0.3,
+    posix-paths,
+    process,
+    random,
+    unix >=2.7,
+    utf8-string,
 
 executable hmp3
   import: opts
@@ -88,12 +97,12 @@ executable hmp3
   hs-source-dirs: app
   ghc-options: -threaded
   build-depends:
-    , base
-    , bytestring
-    , hmp3-ng
-    , optparse-applicative
-    , unix
-    , utf8-string
+    base,
+    bytestring,
+    hmp3-ng,
+    optparse-applicative,
+    unix,
+    utf8-string,
 
 test-suite test
   import: opts
@@ -101,18 +110,19 @@ test-suite test
   main-is: Main.hs
   hs-source-dirs: test
   other-modules:
-      ConfigSpec
-      CoreSpec
-      LexerSpec
-      StyleSpec
-      TreeSpec
-      WidthSpec
+    ConfigSpec
+    CoreSpec
+    LexerSpec
+    StyleSpec
+    TreeSpec
+    WidthSpec
+
   build-depends:
-    , base
-    , bytestring
-    , clock
-    , hmp3-ng
-    , tasty           >=1.4
-    , tasty-hunit     >=0.10
-    , utf8-string
+    base,
+    bytestring,
+    clock,
+    hmp3-ng,
+    tasty >=1.4,
+    tasty-hunit >=0.10,
+    utf8-string,
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -67,7 +67,7 @@ library
       ncursesw
   build-depends:
     , array
-    , base ==4.*
+    , base >=4.15 <5
     , bytestring >=0.10
     , clock
     , containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.28
+resolver: lts-24.44
 system-ghc: true
 compiler-check: newer-minor
 


### PR DESCRIPTION
The plan is (a) to publish a Hackage release after this is merged, largely to get the fix in #103 in; and (b) that this will be the last release supporting GHC 9.0 and mpg321 (see #82).

This covers a collection of code maintenance checklist items, and some minimal rearrangement to eliminate the boot file.  A more comprehensive code reorganization is still planned.  This PR shouldn't change any code behavior except maybe some unusual error handling.

Items:

*  The README is updated to reflect support through GHC 9.14, and also a minimum GHC is noted, and the test suite is mentioned.
*  The minimum GHC version is expressed in the Cabal file by bounding `base`.
*  The GitHub action is updated:  Checkout is upped to v6, silencing the Node deprecation warnings.  Tested GHC versions are changed: I verify the asserted minimum works, and the current most recent three (`latest` is 9.14 as of now).
*  Stackage is updated to the newest LTS.
*  The Cabal file is reformatted with [Gild](https://github.com/tfausak/cabal-gild), which seems to be the emerging gold standard (heh), preferred to `cabal format`.  E.g., Ormolu uses it for its Cabal file.  This creates one big diff in the Git history but I expect long-run benefit.
    *  However, as one exception, I preserved the blocks of extensions, which Gild would fully alphabetize.  I may later reconsider this, especially when GHC 9.0 is dropped and the `GHC2021` edition can supersede most of the list.
*  The boot file is gone:  The key input functions are moved from `Keymap.hs` to a new `Keyboard.hs` to eliminate a cycle.  `keyLoop` is now invoked from `app/Main.hs`, with `start` only doing set-up.
*  The previous `run` function being `runForever keyLoop` wasn't technically correct: in the event of a restart, the loop will resume in `mainMode`, which might not be where it should be (although that's edge-case and of minor impact).  On the other hand, `runForever` falls through for some classes of errors.  I'm not really sure what error there would be listening for a key, or at least any seems unrecoverable (and might be one that fell through).  So, we simply shut down in this event, no `runForever`.
*  Minor other touch-ups.