### PR TITLE
Survive dangling symlinks in tree scan; exit nonzero on error shutdown; fix title-bar overflow

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -281,7 +281,7 @@ shutdown ms = do
         void $ waitForProcess pid
     UI.end
     whenJust ms \s -> hPutStrLn stderr s *> hFlush stderr
-    exitImmediately ExitSuccess
+    exitImmediately $ maybe ExitSuccess (const $ ExitFailure 1) ms
 
 ------------------------------------------------------------------------
 -- 

--- a/Tree.hs
+++ b/Tree.hs
@@ -126,10 +126,11 @@ sift :: [RawFilePath] -> IO ([RawFilePath], [RawFilePath])
 sift []     = pure ([], [])
 sift (p:ps) = do
     it@(fs,ds) <- sift ps
-    isDir <- isDirectory <$> getFileStatus p
-    perm <- fileAccess p True False isDir
-    pure if
-        | not perm -> it
-        | isDir    -> (fs, p:ds)
-        | True     -> (p:fs, ds)
+    handle @IOException (\_ -> pure it) do
+        isDir <- isDirectory <$> getFileStatus p
+        perm <- fileAccess p True False isDir
+        pure if
+            | not perm -> it
+            | isDir    -> (fs, p:ds)
+            | True     -> (p:fs, ds)
 

--- a/UI.hs
+++ b/UI.hs
@@ -370,7 +370,7 @@ playTitle dd =
     side    = (x - modlen) `div` 2
     gap     = x - modlen - lsize - rsize
     gapl    = 1 `max` ((side - lsize) `min` gap)
-    gapr    = 1 `max` (gap - gapl)
+    gapr    = 0 `max` (gap - gapl)
     modlen  = 6 -- length modes
     hl      = titlebar . config $ drawState dd
 


### PR DESCRIPTION
Three small fixes, one commit each.

### 1. Tree scan aborts on dangling symlinks (Tree.hs)

`getFileStatus` throws on a dangling symlink (or a file deleted mid-scan), and on the recursive scan path (`loop` → `expandDir` → `sift`) nothing catches it — only the command-line `sift fs` in `buildTree` is wrapped. One stale symlink anywhere in the music tree aborts startup:

```
*** Exception: /tmp/sift-test/music/broken-link: getFileStatus: does not exist (No such file or directory)
```

Fix: skip unstat-able entries in `sift`, matching the existing treatment of unreadable ones (`| not perm -> it`).

### 2. Error shutdowns report exit status 0 (Core.hs)

`shutdown` ends with `exitImmediately ExitSuccess` unconditionally, including on error paths like `Cannot find mpg123 in path`. And since `exitImmediately` is `_exit(2)`, the `exitWith (ExitFailure 1)` after `shutdown Nothing` in Main's `exitHandler` is unreachable. Fix: exit 1 when `shutdown` was given an error message.

### 3. Title bar one cell too wide when the left gap saturates (UI.hs)

In `playTitle`'s `gap >= 2` branch the rendered width is `lsize + gapl + modlen + gapr + rsize`, which equals the screen width `x` iff `gapl + gapr == gap`. When `side - lsize >= gap`, `gapl` saturates at `gap`, and ``gapr = 1 `max` (gap - gapl)`` then forces an extra cell — the title wraps and pushes the playlist down a row. Fix: ``0 `max` ...``.

### Verification

Built locally with GHC 9.14.1; `cabal test` passes (80/80). The symlink fix was exercised in ghci: `buildTree` over a directory containing a dangling symlink throws on master (output above) and scans cleanly with this patch, still finding the `.mp3` next to the bad link. Fixes 2 and 3 are verified by hand-trace (the `gapl`/`gapr` arithmetic re-derived above), not at runtime.

---
*This came out of an AI review pass Jeremy ran over your repos for fun. Every finding was verified as described above, but the usual skepticism applies.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)