### PR TITLE
Exit code reflects error; fix excess gap edge case.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -43,7 +43,7 @@ import Data.Tuple               (swap)
 import Control.Monad.State.Strict
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
                                  getXdgDirectory, XdgDirectory(..))
-import System.IO                (hPutStrLn, hGetLine, stderr, hFlush)
+import System.IO                (hPutStrLn, hGetLine, stderr)
 import System.Process           (runInteractiveProcess, waitForProcess)
 import System.Clock             (TimeSpec(..), diffTimeSpec)
 import System.Random            (randomR, newStdGen)
@@ -273,8 +273,9 @@ shutdown ms = do
         discardErrors $ sendMpg Quit
         void $ waitForProcess pid
     UI.end
-    whenJust ms \s -> hPutStrLn stderr s *> hFlush stderr
-    exitImmediately ExitSuccess
+    exitImmediately =<< case ms of
+        Just s -> hPutStrLn stderr s *> pure (ExitFailure 1)
+        _      -> pure ExitSuccess
 
 ------------------------------------------------------------------------
 -- 

--- a/UI.hs
+++ b/UI.hs
@@ -369,8 +369,8 @@ playTitle dd =
     rsize   = 2 + P.length time + P.length ver
     side    = (x - modlen) `div` 2
     gap     = x - modlen - lsize - rsize
-    gapl    = 1 `max` ((side - lsize) `min` gap)
-    gapr    = 1 `max` (gap - gapl)
+    gapl    = 1 `max` ((side - lsize) `min` (gap - 1))
+    gapr    = gap - gapl
     modlen  = 6 -- length modes
     hl      = titlebar . config $ drawState dd
 


### PR DESCRIPTION
Claude Code usefully flagged a CLI infelicity (2) and a rare bug (3) in #108, but its fixes weren't so good.  This PR provides a nicer fix for (2) and a correct fix for (3).  There should be a better solution for (2) after some other code work.

Tangentially, I don't think we need to flush stderr since the process close will do that.