### PR TITLE
Catch Curses crashes.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -75,7 +75,11 @@ data Options = Options
 start :: Options -> Tree -> IO ()
 start opts (Tree folders music) = do
 
-    config <- UI.start
+    config <- catch @SomeException UI.start \err -> do
+        -- An uncaught exception here would deadlock.
+        -- XXX more state model revisions should obviate need
+        hPutStrLn stderr $ "Curses failed to start: " ++ show err
+        exitImmediately (ExitFailure 1) *> error "Unix <2.8"
     bootTime <- getMonoTime
     let size = length music
     mode <- readState


### PR DESCRIPTION
This is a workaround for an issue in #101 flagged by Claude Code, that if the Curses initiation fails, there will be a deadlock since there is no state for `shutdown` to read from.  I expect this to be temporary, since probably I'll pull `exiting` and `mpgPid` out of the `HState`, and indeed may drop `exiting` completely.

Note also the clunky workaround for `unix` before 2.8.  We can drop that with a higher minimum GHC.