### PR TITLE
Minimum GHC 9.2, unlocking simplifications.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     strategy:
       matrix:
-        ghc: ['9.0.1', '9.10', '9.12', 'latest']
+        ghc: ['9.2.1', '9.10', '9.12', 'latest']
     name: GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v6

--- a/Core.hs
+++ b/Core.hs
@@ -79,7 +79,7 @@ start opts (Tree folders music) = do
         -- An uncaught exception here would deadlock.
         -- XXX more state model revisions should obviate need
         hPutStrLn stderr $ "Curses failed to start: " ++ show err
-        exitImmediately (ExitFailure 1) *> error "Unix <2.8"
+        exitImmediately $ ExitFailure 1
     bootTime <- getMonoTime
     let size = length music
     mode <- readState

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ versions, which were only minor changes, mostly the automated
 regeneration of a `configure` file (now gone).
 
 *  The code has been updated to compile under recent GHC (tested
-through 9.14; minimum supported 9.0) and libraries.  This required
+through 9.14; minimum supported 9.2) and libraries.  This required
 rewriting or entirely replacing large sections, mainly low-level
 optimizations.
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -24,7 +24,7 @@ source-repository head
   location: https://github.com/galenhuntington/hmp3-ng
 
 common opts
-  default-language: Haskell2010
+  default-language: GHC2021
   default-extensions:
     BlockArguments
     MultiWayIf
@@ -33,15 +33,6 @@ common opts
     -- In GHC2024
     DerivingStrategies
     LambdaCase
-    -- In GHC2021 (soon!)
-    BangPatterns
-    GeneralizedNewtypeDeriving
-    NamedFieldPuns
-    NumericUnderscores
-    ScopedTypeVariables
-    StandaloneDeriving
-    TupleSections
-    TypeApplications
 
   ghc-options:
     -Wall
@@ -75,7 +66,7 @@ library
 
   build-depends:
     array,
-    base >=4.15 && <5,
+    base >=4.16 && <5,
     bytestring >=0.10,
     clock,
     containers,
@@ -87,7 +78,7 @@ library
     posix-paths,
     process,
     random,
-    unix >=2.7,
+    unix >=2.8,
     utf8-string,
 
 executable hmp3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-24.44
+resolver: lts-24.45
 system-ghc: true
 compiler-check: newer-minor
 


### PR DESCRIPTION
Finally dropping GHC 9.0 and its limitations.  This allows a few immediate simplifications, which are done.

Also a trivial Stackage bump.