### PR TITLE
Drop clockLoop thread, update on every frame.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -84,7 +84,6 @@ start opts (Tree folders music) = do
         [ mpgLoop
         , mpgInput
         , refreshLoop
-        , clockLoop
         , uptimeLoop
         , errorLoop
         ]
@@ -110,7 +109,6 @@ start opts (Tree folders music) = do
         , modal        = Nothing
         , playHist     = mempty
         , searchHist   = []
-        , clockUpdate  = False
         , miniFocused  = False
         , exiting      = False
         , status       = Stopped
@@ -230,12 +228,6 @@ showTimeDiff = showTimeDiff_ False
 
 ------------------------------------------------------------------------
 
--- | Periodically wake up and redraw the clock
-clockLoop :: IO ()
-clockLoop = runForever $ threadDelay 125_000 *> UI.refreshClock
-
-------------------------------------------------------------------------
-
 -- | Handle, and display errors produced by mpg123
 errorLoop :: IO ()
 errorLoop = runForever $
@@ -290,7 +282,7 @@ handleMsg (S t) = do
 
 handleMsg (R f) = do
     silentlyModifyHS \st -> st { clock = Just f }
-    getsHS clockUpdate >>= flip when UI.refreshClock
+    UI.refreshClock
 
 ------------------------------------------------------------------------
 --
@@ -308,15 +300,11 @@ seekRight = seek \g -> currentFrame g + min 400 (framesLeft g)
 seekStart :: IO ()
 seekStart = seek $ const 0
 
-
 -- | Generic seek
 seek :: (Frame -> Int) -> IO ()
 seek fn = do
     mfr <- getsHS clock
-    whenJust mfr \fr -> do
-        sendMpg $ Jump (fn fr)
-        silentlyModifyHS $ \st -> st { clockUpdate = True }
-
+    whenJust mfr \fr -> sendMpg $ Jump $ fn fr
 
 ------------------------------------------------------------------------
 

--- a/State.hs
+++ b/State.hs
@@ -34,7 +34,6 @@ data HState = HState
     , current         :: !Int                  -- currently playing mp3
     , cursor          :: !Int                  -- mp3 under the cursor
     , clock           :: !(Maybe Frame)        -- current clock value
-    , clockUpdate     :: !Bool
     , randomGen       :: !StdGen               -- random seed
     , mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
     , spawns          :: !Integer              -- count of decoder spawns


### PR DESCRIPTION
In #83 I decided to up the frequency of the clock loop, thinking we'd get a boost in fidelity with a factor of 4, which modern computers (vs. 2005) should be able to handle.  However, it turns out, per #110, that we were updating on every frame all along, at least for the entire run of the player after any keypress seek.

This bug has been present since 2005, and… it's been fine?  So now however many Moore's law iterations later, I believe we can just make this behavior official.

Now that we're updating every frame, we don't need the `clockLoop` thread at all, nor do we need the (broken) `clockUpdate` in the state.

(As an aside, I've been considering adding fractional seconds to the clocks, so speeding this up anyway was already a possibility.)

Closes #110.