### PR TITLE
Modal can only cover song list.

### DIFF
--- a/UI.hs
+++ b/UI.hs
@@ -459,7 +459,6 @@ redrawJustClock = Draw $ discardErrors do
     drawLine $ progressBar dd
     Curses.wMove Curses.stdScr 2 0   -- hardcoded!
     drawLine $ pTimes dd
-    when (h < 45) $ renderModals st (Size h w) -- small screen modals paint over clock
 
 ------------------------------------------------------------------------
 -- | General modal renderer.
@@ -467,11 +466,11 @@ renderModal :: HState -> Size -> ModalMaker -> IO ()
 renderModal st (Size h w) mkr = do
     let (mw, modal') = mkr w
         hoffset = max 0 $ (w - mw) `div` 2
-        mlines  = min h $ length modal'
-        voffset = (h - mlines) `div` 2
+        vislines = (h - 5) `min` length modal'
+        voffset = ((h - vislines) `div` 2) `max` 4
         sty = modals $ config st
     Curses.wMove Curses.stdScr voffset hoffset
-    for_ (take mlines modal') \t -> do
+    for_ (take vislines modal') \t -> do
         drawLine $ Fast (toWidth mw t) sty
         (y', _) <- Curses.getYX Curses.stdScr
         Curses.wMove Curses.stdScr (y'+1) hoffset


### PR DESCRIPTION
This gets rid of the arbitrary constant 45 for deciding when a clock redraw requires a modal redraw.  Clock redraws can be quite frequent (see #120).  Instead, the modal can only appear over the song list, so the information at the top is not covered.  The minibuffer is also not covered.  It makes some sense to leave these informational widgets visible.

The cost is small: 5 lines, in a time when terminal heights are usually quite large.  In fact, I expect in normal usage this change won't matter, and it simplifies the code.

Note that modals can be cut off at the bottom (but this was already the case).  Making them scrollable seems too much.