### PR TITLE
Rename Tree to Playlist.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -28,8 +28,7 @@ import Syntax
 import Lexer (mpgParser)
 import State
 import Style
-import Tree hiding (File, Dir)
-import qualified Tree (File,Dir)
+import Playlist
 import qualified UI
 
 import qualified Data.ByteString.Char8 as P
@@ -65,8 +64,8 @@ data Options = Options
     }
 
 -- | Sets up state, spawns sub-threads, and starts player.
-start :: Options -> Tree -> IO ()
-start opts (Tree folders music) = do
+start :: Options -> Playlist -> IO ()
+start opts (Playlist folders music) = do
 
     config <- catch @SomeException UI.start \err -> do
         -- An uncaught exception here would deadlock.
@@ -460,8 +459,8 @@ jumpToDir fn = modifyHS_ $ \st -> if size st == 0 then st else
 -- in the regex search stuff below
 --
 class Lookup a       where extract :: a -> RawFilePath
-instance Lookup Tree.Dir  where extract = takeFileName . dname
-instance Lookup Tree.File where extract = fbase
+instance Lookup Dir  where extract = takeFileName . dname
+instance Lookup File where extract = fbase
 
 jumpToMatchFile :: Maybe String -> Bool -> IO ()
 jumpToMatchFile re sw = genericJumpToMatch re sw k sel

--- a/Playlist.hs
+++ b/Playlist.hs
@@ -2,11 +2,7 @@
 -- Copyright (c) 2019-2020, 2025-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
---
--- functions for manipulating file trees
---
-
-module Tree (module Tree, RawFilePath) where
+module Playlist (module Playlist, RawFilePath) where
 
 import Base
 
@@ -38,13 +34,13 @@ data File =
     File { fbase :: !RawFilePath      -- ^ basename of file
          , fdir  :: !Int }          -- ^ index of Dir entry 
 
-data Tree = Tree !DirArray !FileArray
+data Playlist = Playlist !DirArray !FileArray
 
 --
 -- | Given the start directories, populate the dirs and files arrays
 --
-buildTree :: [RawFilePath] -> IO Tree
-buildTree fs = do
+buildPlaylist :: [RawFilePath] -> IO Playlist
+buildPlaylist fs = do
     -- note we will lose the ordering of files given on cmd line.
     (os, dirs) <- catch @SomeException (sift fs)
         \e -> print e *> exitWith (ExitFailure 1)
@@ -64,11 +60,11 @@ buildTree fs = do
         dirsArray = listArray (0,length dirls - 1) (reverse dirls)
         fileArray = listArray (0, n-1) (reverse filels)
 
-    pure $! Tree dirsArray fileArray
+    pure $! Playlist dirsArray fileArray
 
--- | Is the tree empty?
-isEmpty :: Tree -> Bool
-isEmpty (Tree _ files) = null files
+-- | Is the playlist empty?
+isEmpty :: Playlist -> Bool
+isEmpty (Playlist _ files) = null files
 
 -- | Create nodes based on dirname for orphan files on cmdline
 doOrphans :: [RawFilePath] -> [(RawFilePath, [RawFilePath])]

--- a/State.hs
+++ b/State.hs
@@ -10,7 +10,7 @@ module State where
 import Base
 
 import Syntax                   (Status, Mode, Frame, Info, Id3, Pretty(ppr))
-import Tree                     (FileArray, DirArray)
+import Playlist                 (FileArray, DirArray)
 import Style                    (StringA, UIStyle)
 
 import Data.ByteString          (hPut)

--- a/UI.hs
+++ b/UI.hs
@@ -21,7 +21,7 @@ module UI (
 import Base
 
 import Style
-import Tree                     (File(fdir, fbase), Dir(dname))
+import Playlist                 (File(fdir, fbase), Dir(dname))
 import State
 import Syntax
 import Config

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,7 @@ import Base
 import Core     (start, shutdown, Options(..))
 import qualified Config
 import Keymap   (keyLoop)
-import Tree     (buildTree, isEmpty)
+import Playlist (buildPlaylist, isEmpty)
 
 import System.IO            (hPrint, stderr)
 import System.Posix.Signals (installHandler, sigTERM, sigPIPE, sigINT, sigHUP
@@ -72,12 +72,12 @@ parserInfo = info (invocation <**> versionOpt <**> helper) $
 main :: IO ()
 main = do
     (opts, args) <- customExecParser (prefs showHelpOnEmpty) parserInfo
-    tree <- buildTree args
-    when (isEmpty tree) $
+    list <- buildPlaylist args
+    when (isEmpty list) $
         errorWithoutStackTrace "Error: No music files found."
     initSignals
     err <- either id absurd <$> try @SomeException do
-        start opts tree
+        start opts list
         keyLoop
     shutdown $ Just $ "Error: " ++ show err
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -48,10 +48,10 @@ library
     Keyboard
     Keymap
     Lexer
+    Playlist
     State
     Style
     Syntax
-    Tree
     UI
     Width
 
@@ -103,8 +103,8 @@ test-suite test
     ConfigSpec
     CoreSpec
     LexerSpec
+    PlaylistSpec
     StyleSpec
-    TreeSpec
     WidthSpec
 
   build-depends:

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,8 +5,8 @@ import Test.Tasty
 import qualified ConfigSpec
 import qualified CoreSpec
 import qualified LexerSpec
+import qualified PlaylistSpec
 import qualified StyleSpec
-import qualified TreeSpec
 import qualified WidthSpec
 
 main :: IO ()
@@ -15,7 +15,7 @@ main = defaultMain $ testGroup "hmp3-ng"
     , CoreSpec.tests
     , LexerSpec.tests
     , StyleSpec.tests
-    , TreeSpec.tests
+    , PlaylistSpec.tests
     , WidthSpec.tests
     ]
 

--- a/test/PlaylistSpec.hs
+++ b/test/PlaylistSpec.hs
@@ -1,12 +1,12 @@
-module TreeSpec (tests) where
+module PlaylistSpec (tests) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Tree (doOrphans, merge)
+import Playlist (doOrphans, merge)
 
 tests :: TestTree
-tests = testGroup "Tree"
+tests = testGroup "Playlist"
     [ testGroup "doOrphans"
         [ testCase "empty"
             $ doOrphans []                       @?= []
@@ -36,3 +36,4 @@ tests = testGroup "Tree"
             $ merge [("a", ["1"]), ("b", ["2"]), ("a", ["3"])]   @?= [("a", ["1", "3"]), ("b", ["2"])]
         ]
     ]
+


### PR DESCRIPTION
I planned to rename this on the grounds that `Tree` is already a structure in Haskell's `base`, and it would be confusing to use the name here, and who knows I might even want one of those trees.  Claude Code independently flagged this for a different reason, that this data structure is not a tree at all.