### PR TITLE
Control-C and exit work.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -249,17 +249,16 @@ mpgInput = runForever $ do
 ------------------------------------------------------------------------
 
 -- | Close most things. Important to do all the jobs:
--- TODO maybe releaseSignals here in case mpg is frozen?
---   and/or move UI.end up?
+-- TODO maybe releaseSignals here?
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
+    UI.end
     silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState
     mpid <- getsHS mpgPid
     whenJust mpid \pid -> do
         discardErrors $ sendMpg Quit
         void $ waitForProcess pid
-    UI.end
     exitImmediately =<< case ms of
         Just s -> hPutStrLn stderr s *> pure (ExitFailure 1)
         _      -> pure ExitSuccess

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -47,9 +47,9 @@ keyLoop = go mainMode where
 mainMode :: KeyMap
 mainMode = KeyMap \c -> getsHS modal >>= \case
 
-    Just ExitModal -> case c of
-        'y' -> shutdown Nothing $> undefined -- shutdown never returns
-        _   -> closeModal $> mainMode
+    Just ExitModal
+        | c `elem` ['y', 'Y', '\^C'] -> shutdown Nothing $> undefined
+        | True                       -> closeModal $> mainMode
 
     Just (HistModal hist) -> do
         for_ (M.lookup c historyKeyMap >>= (hist !?)) (jump . fst . snd)
@@ -60,7 +60,7 @@ mainMode = KeyMap \c -> getsHS modal >>= \case
             toggleFocus
             hist <- getsHS searchHist
             searchMode c $ Zipper "" hist []
-        | c == 'q' ->
+        | c `elem` ['q', '\^C'] ->
             forcePause *> setsModal (const $ Just ExitModal) $> mainMode
         | c `elem` ['H', ';'] ->
             showHist $> mainMode

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,9 +12,8 @@ import Config qualified
 import Keymap   (keyLoop)
 import Playlist (buildPlaylist, isEmpty)
 
-import System.IO            (hPrint, stderr)
-import System.Posix.Signals (installHandler, sigTERM, sigPIPE, sigINT, sigHUP
-                            ,sigALRM, sigABRT, Handler(Ignore, Default, Catch))
+import System.Posix.Signals (installHandler, Handler(Ignore, Default, Catch),
+                             sigTERM, sigPIPE, sigINT, sigHUP , sigALRM, sigABRT)
 
 import Data.ByteString.UTF8 qualified as UTF8
 
@@ -35,8 +34,7 @@ initSignals = do
 exitHandler :: IO ()
 exitHandler = do
     releaseSignals  -- in case shutdown itself gets stuck
-    catch @SomeException (shutdown Nothing) (hPrint stderr)
-    exitWith $ ExitFailure 1
+    shutdown $ Just "Killed"
 
 releaseSignals :: IO ()
 releaseSignals =

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -89,7 +89,6 @@ executable hmp3
   ghc-options: -threaded
   build-depends:
     base,
-    bytestring,
     hmp3-ng,
     optparse-applicative,
     unix,


### PR DESCRIPTION
Partially handles #106.

Control-C now acts more like it would be expected to: it directs towards the quit path, equivalent to `q`.  A ^C on the quit confirm modal then exits.

Other exit changes:

*  `UI.end` is moved up.  This produces better results in odd cases such as mpg123 being frozen.  A Control-C will likely kill the mpg123 process once we're out of Curses, unblocking the wait and exiting.  It also means there won't be stacked shutdowns, that is, it'll be intercepted here since `UI.end` takes and keeps the draw lock.  I might still consider releasing signals here in case mpg123 is actually unresponsive, but it's probably not necessary since follow-ups will trigger `exitHandler`, which releases.  The test case I had was `mkfifo test.mp3` and `hmp3 test.mp3`; we don't want to be unable to exit in that (admittedly weird and highly unexpected) case.
*  The `exitHandler` for signals that stop the process no longer catch and fall through to a secondary shutdown.  This doesn't seem of help in almost any case, and now with `UI.end` up the second shutdown would block anyway.
*  Minor:  Capital `Y` is accepted by the exit modal.  I regrouped some imports.  A signal exit behaves more like an error exit, with "Killed".

In short, hitting Control-C enough times should get you out.

Finally, `bytestring` is not needed for the executable and so is removed from the dependencies.