### PR TITLE
Bump hscurses in stack.yaml to latest.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,5 @@ system-ghc: true
 compiler-check: newer-minor
 
 extra-deps:
-- hscurses-1.4.2.0@sha256:185f294036aaced6a4cf72c994339286e8e7886f5a327c3ccac898066985c528,2118
+- hscurses-1.5.0.0@sha256:5bd0d1840ede4a99becdbb7a6b68ee6abe14f4b4a4cdfce373fcf46b9e119650,3851
 


### PR DESCRIPTION
Through oversight, this has lagged.  Maybe this will help with intermittent Stack CI issues?