### PR TITLE
Use monotonic time on all platforms, dropping "boot time".

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- Copyright (c) 2020-2026 Galen Huntington
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -41,12 +39,7 @@ discardErrors :: IO () -> IO ()
 discardErrors = X.handle @SomeException (\_ -> pure ())
 
 getMonoTime :: IO TimeSpec
-getMonoTime = getTime
-#if linux_HOST_OS
-    Boottime
-#else
-    Monotonic
-#endif
+getMonoTime = getTime Monotonic
 
 whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
 whenJust = flip $ maybe $ pure ()


### PR DESCRIPTION
As of Linux 4.17 (2018), these clocks are identical, so we can drop this CPP and OS check, and not have to worry it might introduce any funny platform dependence.

If anyone is stuck on an old Linux kernel, the only negative effect is that the uptime clock might not count time while the computer is suspended, not a major UI defect.