### PR TITLE
Misc code work.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -33,7 +33,7 @@ import UI qualified
 import Data.ByteString.Char8 qualified as P
 import Data.Sequence qualified as Seq
 
-import Data.Array               ((!), bounds, Array)
+import Data.Array               ((!), Array)
 import Data.Proxy
 import Data.Tuple               (swap)
 import Control.Monad.State.Strict
@@ -447,10 +447,9 @@ jumpToPrevDir = jumpToDir (\i _   -> max (i-1) 0)
 
 -- | Generic jump to dir
 jumpToDir :: (Int -> Int -> Int) -> IO ()
-jumpToDir fn = modifyHS_ $ \st -> if size st == 0 then st else
+jumpToDir fn = modifyHS_ \st ->
     let i   = fdir (music st ! cursor st)
-        len = 1 + (snd . bounds $ folders st)
-        d   = fn i len
+        d   = fn i (length $ folders st)
     in st { cursor = dlo (folders st ! d) }
 
 ------------------------------------------------------------------------
@@ -463,14 +462,12 @@ instance Lookup File where extract = fbase
 
 jumpToMatchFile :: Maybe String -> Bool -> IO ()
 jumpToMatchFile re sw = genericJumpToMatch re sw k sel
-    where k st = (music st, if size st == 0 then -1 else cursor st, size st)
+    where k st = (music st, cursor st, size st)
           sel i _ = i
 
 jumpToMatchDir :: Maybe String -> Bool -> IO ()
 jumpToMatchDir re sw = genericJumpToMatch re sw k sel
-    where k st = (folders st
-                     , if size st == 0 then -1 else fdir (music st ! cursor st)
-                     , 1 + (snd . bounds $ folders st))
+    where k st = (folders st, fdir (music st ! cursor st), length $ folders st)
           sel i st = dlo (folders st ! i)
 
 genericJumpToMatch :: Lookup a

--- a/UI.hs
+++ b/UI.hs
@@ -193,9 +193,7 @@ pPlaying dd = FancyS $ map (, defaultSty) $ "  " : line where
 pId3 :: DrawData -> ByteString
 pId3 DD{drawState=st} = case id3 st of
     Just i  -> id3str i
-    Nothing -> case size st of
-        0 -> "(empty)"
-        _ -> fbase $ music st ! current st
+    Nothing -> fbase $ music st ! current st
 
 -- | mp3 information
 pInfo :: DrawData -> ByteString
@@ -315,26 +313,22 @@ pMode dd = take 4 $ map toLower $ show $ mode $ drawState dd
 
 ------------------------------------------------------------------------
 
--- | "x/n dir(s)  y/m file(s)" cursor position read-out.
+-- | "x/n dirs y/m files" cursor position read-out.
 playInfo :: DrawData -> ByteString
 playInfo dd = mconcat
-    -- TODO pregenerate as template
     [ spaces (P.length numd - P.length curd)
-    , curd, "/", numd, " dir", onPlural (snd . bounds $ folders st) "" "s"
-    , " "
-    , spaces (P.length numf - P.length curf)
-    , curf, "/", numf, " file", onPlural (size st) "" "s"
+    , curd, "/", numd, " dirs"
+    , spaces (1 + P.length numf - P.length curf)
+    , curf, "/", numf, " files"
     ]
   where
     st   = drawState dd
     tobs = P.pack . show
-    onPlural 1 s _ = s
-    onPlural _ _ p = p
     curf  = tobs $ 1 + cursor st
     numf  = tobs $ size st
     mydir = fdir $ music st ! cursor st
     curd  = tobs $ 1 + mydir
-    numd  = tobs $ 1 + snd (bounds $ folders st)
+    numd  = tobs $ length $ folders st
 
 -- | The top title bar: cursor position + play indicator + uptime + version.
 playTitle :: DrawData -> StringA
@@ -427,10 +421,7 @@ playList dd@DD{ drawSize=Size y x, drawPos=Pos{posY=o}, drawState=st } =
         : map (, sty) v
       where
         sty' = if sty == sty2 || sty == sty3 then sty2 else sty1
-        d = toMaxWidth (indent - 1) $ takeFileName
-                $ case size st of
-                    0 -> "(empty)"
-                    _ -> dname $ folders st ! i
+        d = toMaxWidth (indent - 1) $ takeFileName $ dname $ folders st ! i
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
A few small items:

*  There are a number of checks if the playlist is empty, which are unnecessary because it can never be.  The process exits on start-up on empty playlist, and anyhow if it didn't the player would crash.
    *  This eliminates the last `(empty)` UI string.
*  There was some hacky bounds arithmetic for the folder count, now replaced with `length`.
*  I dropped `onPlural` since "1/1 dirs" doesn't really read worse than "1/1 dir", and it's an edge case, and anyway it was buggy because it was off by one so only showed the singular with _two_ dirs.
*  Other even more minor stuff.