### PR TITLE
Use mpg123 --remote-err, drop errorLoop thread.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -39,7 +39,7 @@ import Data.Tuple               (swap)
 import Control.Monad.State.Strict
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
                                  getXdgDirectory, XdgDirectory(..))
-import System.IO                (hPutStrLn, hGetLine, stderr)
+import System.IO                (hPutStrLn, stderr)
 import System.Process           (runInteractiveProcess, waitForProcess)
 import System.Clock             (TimeSpec(..), diffTimeSpec)
 import System.Random            (randomR, newStdGen)
@@ -85,7 +85,6 @@ start opts (Playlist folders music) = do
         , mpgInput
         , refreshLoop
         , uptimeLoop
-        , errorLoop
         ]
 
     putMVar hState HState
@@ -158,12 +157,12 @@ mpgLoop = runForever do
     case mmpg of
       Nothing     -> shutdown $ Just $ "Cannot find " ++ mp3Tool ++ " in path"
       Just mppath -> do
-        mv <- try $ runInteractiveProcess mppath ["-R", "-"] Nothing Nothing
+        mv <- try $ runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing
         case mv of
           Left (ex :: SomeException) ->
             warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
-          Right (writeh, readh, errh, pid) -> do
+          Right (writeh, _, errh, pid) -> do
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { mpgPid    = Just pid
                 , status    = Stopped
@@ -172,7 +171,7 @@ mpgLoop = runForever do
                 , spawns    = sp
                 }, sp)
 
-            putMVar mpg Mpg { readh, errh, writeh }
+            putMVar mpg Mpg { errh, writeh }
 
             when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
             catch @SomeException (void $ waitForProcess pid) (const $ pure ())
@@ -229,20 +228,13 @@ showTimeDiff = showTimeDiff_ False
 
 ------------------------------------------------------------------------
 
--- | Handle, and display errors produced by mpg123
-errorLoop :: IO ()
-errorLoop = runForever $
-    readMVar mpg <&> errh >>= hGetLine >>= (warnA . ("mpg123 err: " ++))
-
-------------------------------------------------------------------------
-
 -- | Handle messages arriving over a pipe from the decoder process. When
 -- shutdown kills the other end of the pipe, hGetLine will fail, so we
 -- take that chance to exit.
 --
 mpgInput :: IO ()
 mpgInput = runForever $ do
-    line <- P.hGetLine =<< readh <$> readMVar mpg
+    line <- P.hGetLine =<< errh <$> readMVar mpg
     case mpgParser line of
         Right m       -> handleMsg m
         Left (Just e) -> warnA ("mpg123: " ++ e)

--- a/State.hs
+++ b/State.hs
@@ -81,11 +81,7 @@ setModified = void $ tryPutMVar modified ()
 ------------------------------------------------------------------------
 -- The decoder.
 
-data Mpg = Mpg
-    { writeh :: !Handle
-    , readh  :: !Handle
-    , errh   :: !Handle
-    }
+data Mpg = Mpg { errh :: !Handle, writeh :: !Handle }
 
 mpg :: MVar Mpg
 mpg = unsafePerformIO newEmptyMVar


### PR DESCRIPTION
Closes #99.  This is the recommended approach per that issue, and, as far as I can tell, without this option stderr is not used at all, so `errorLoop` wasn't doing anything.  I tried commenting out the `@E` parsing and inducing an error (seeking in a stopped state), and nothing showed up via `errorLoop`.  So it may have been effectively dead code.

I do worry there might still be something irregularly emitted on stderr, but I'm deferring to the documentation saying this is the right way to do it.

We no longer need the read handle at all anymore.

Finally, there was a `-` argument also sent to mpg123.  It may have once done something (or not), but it is apparently irrelevant now.