### PR TITLE
CI: install libpcre3-dev so Ubuntu runners can build pcre-light.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,25 +2,28 @@ on: [push]
 name: build
 jobs:
   cabal:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
         ghc: ['9.2.1', '9.10', '9.12', 'latest']
     name: GHC ${{ matrix.ghc }}
     steps:
       - uses: actions/checkout@v6
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcre3-dev
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
   stack:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     name: Stack
     steps:
       - uses: actions/checkout@v6
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcre3-dev
       - uses: haskell-actions/setup@v2
         with:
           enable-stack: true
       - run: stack test
-


### PR DESCRIPTION
Claude Code:

Ubuntu 24.04 (which is what 'ubuntu-latest' resolves to and what 22.04 will roll over to) no longer ships libpcre3-dev preinstalled, which is why pinning to 22.04 was masking the issue: pcre-light fails its system- dependency check on 24.04 with "Missing (or bad) C library: pcre".

Two GitHub-runner options:

  1. Install libpcre3-dev with apt before building.  Standard pattern for unbundled native deps; this is what ncursesw does implicitly via pkgconfig-depends (ncurses is preinstalled, pcre is not).

  2. Switch from pcre-light to pcre2 / regex-tdfa / etc.  Much larger change for an inactive dependency that works fine where the lib is present.

This commit takes option (1) and unpins to 'ubuntu-latest', which is where the matrix should have been all along.  Both the cabal and stack jobs need the install since both build the library.