### PR TITLE
Replace pcre with something supported.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,11 +2,12 @@ on: [push]
 name: build
 jobs:
   cabal:
-    runs-on: 'ubuntu-22.04'
     strategy:
       matrix:
-        ghc: ['9.2.1', '9.10', '9.12', 'latest']
-    name: GHC ${{ matrix.ghc }}
+        ghc: ['latest']
+        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
+    runs-on: ${{ matrix.system }}
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
     steps:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
@@ -15,7 +16,7 @@ jobs:
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
   stack:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     name: Stack
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,20 @@
 on: [push]
 name: build
 jobs:
+  cabal:
+    strategy:
+      matrix:
+        ghc: ['latest']
+        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
+    runs-on: ${{ matrix.system }}
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - run: cabal build all
+      - run: cabal test all --test-show-details=streaming
   stack:
     runs-on: 'ubuntu-latest'
     name: Stack

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,20 +1,6 @@
 on: [push]
 name: build
 jobs:
-  cabal:
-    strategy:
-      matrix:
-        ghc: ['latest']
-        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
-    runs-on: ${{ matrix.system }}
-    name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: haskell-actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
-      - run: cabal build all
-      - run: cabal test all --test-show-details=streaming
   stack:
     runs-on: 'ubuntu-latest'
     name: Stack

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['latest']
-        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
+        system: ['ubuntu-24.04', 'ubuntu-26.04']
     runs-on: ${{ matrix.system }}
     name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
     steps:
@@ -15,13 +15,4 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
-  stack:
-    runs-on: 'ubuntu-latest'
-    name: Stack
-    steps:
-      - uses: actions/checkout@v6
-      - uses: haskell-actions/setup@v2
-        with:
-          enable-stack: true
-      - run: stack test
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['latest']
-        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
+        system: ['macos-latest']
     runs-on: ${{ matrix.system }}
     name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
     steps:
@@ -15,13 +15,4 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
-  stack:
-    runs-on: 'ubuntu-latest'
-    name: Stack
-    steps:
-      - uses: actions/checkout@v6
-      - uses: haskell-actions/setup@v2
-        with:
-          enable-stack: true
-      - run: stack test
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['latest']
-        system: ['ubuntu-24.04', 'ubuntu-26.04']
+        system: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
     runs-on: ${{ matrix.system }}
     name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
     steps:
@@ -15,4 +15,13 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
+  stack:
+    runs-on: 'ubuntu-latest'
+    name: Stack
+    steps:
+      - uses: actions/checkout@v6
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+      - run: stack test
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,10 +4,15 @@ jobs:
   cabal:
     strategy:
       matrix:
-        ghc: ['latest']
-        system: ['macos-latest']
-    runs-on: ${{ matrix.system }}
+        system: ['ubuntu-latest']
+        ghc: ['9.2.1', '9.12', 'latest']
+        include:
+          - system: ubuntu-22.04
+            ghc: latest
+          - system: ubuntu-26.04
+            ghc: latest
     name: GHC ${{ matrix.ghc }} on ${{ matrix.system }}
+    runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2
@@ -15,4 +20,13 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
       - run: cabal build all
       - run: cabal test all --test-show-details=streaming
+  stack:
+    runs-on: 'ubuntu-latest'
+    name: Stack
+    steps:
+      - uses: actions/checkout@v6
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+      - run: stack test
 

--- a/Base.hs
+++ b/Base.hs
@@ -30,7 +30,7 @@ import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X
 import Text.Printf as X
 import Text.Read as X (readMaybe)
-import Text.Regex.PCRE.Light (match, compileM, utf8, caseless)
+import Text.Regex.PCRE2 (compCaseless, match, makeRegexOptsM)
 
 import System.Clock
 
@@ -50,9 +50,22 @@ whenJust = flip $ maybe $ pure ()
 (!?) :: [a] -> Int -> Maybe a
 xs !? n = listToMaybe $ drop n xs
 
+
 -- API for regex
 matches :: ByteString -> ByteString -> Bool
+
+-- Layer allowing switching back end
+
+{-
+-- pcre-light version (can't use due to pcre dep)
 matches s = case compileM s [caseless, utf8] of
     Right p -> \t -> isJust $ match p t []
     _       -> const False
+-}
+
+-- regex-pcre2 version
+matches s = case makeRegexOptsM compCaseless 0 s of
+    Just p -> match p
+    _      -> const False
+
 

--- a/Base.hs
+++ b/Base.hs
@@ -30,6 +30,8 @@ import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X
 import Text.Printf as X
 import Text.Read as X (readMaybe)
+import Text.Regex.PCRE.Light (match, compileM, utf8, caseless)
+
 import System.Clock
 
 
@@ -47,4 +49,10 @@ whenJust = flip $ maybe $ pure ()
 -- Compatibility: List.!? only added in GHC 9.8
 (!?) :: [a] -> Int -> Maybe a
 xs !? n = listToMaybe $ drop n xs
+
+-- API for regex
+matches :: ByteString -> ByteString -> Bool
+matches s = case compileM s [caseless, utf8] of
+    Right p -> \t -> isJust $ match p t []
+    _       -> const False
 

--- a/Base.hs
+++ b/Base.hs
@@ -21,7 +21,6 @@ import Data.List as X hiding ((!?))
 import Data.Maybe as X
 import Data.Sequence as X (Seq, (<|), (|>))
 import Data.String as X
-import Data.Text.Encoding (decodeUtf8Lenient)
 import Data.Traversable as X
 import Data.Version as X
 import Data.Void as X
@@ -31,7 +30,7 @@ import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X
 import Text.Printf as X
 import Text.Read as X (readMaybe)
-import Text.Regex.Pcre2 (matchesOpt, Option(Caseless))
+import Text.Regex.Posix (match, makeRegexOptsM, compIgnoreCase)
 
 import System.Clock
 
@@ -52,13 +51,13 @@ whenJust = flip $ maybe $ pure ()
 xs !? n = listToMaybe $ drop n xs
 
 
--- API for regex
+-- API for searching
 matches :: ByteString -> ByteString -> Bool
 
 -- Layer allowing switching back end
 
 {-
--- pcre-light version (can't use due to pcre dep)
+-- pcre-light version (can't use currently due to pcre3 dep)
 matches s = case compileM s [caseless, utf8] of
     Right p -> \t -> isJust $ match p t []
     _       -> const False
@@ -71,8 +70,22 @@ matches s = case makeRegexOptsM compCaseless 0 s of
     _      -> const False
 -}
 
--- pcre2 version (highly inefficient, mass Text conversion)
-matches s t = unsafePerformIO
-    $ handle @SomeException (const $ pure False) $ evaluate
-    $ matchesOpt Caseless (decodeUtf8Lenient s) (decodeUtf8Lenient t)
+{-
+-- pcre2 version (inefficient, mass Text conversion)
+-- needs text dep/import
+matches s =
+    let p = decodeUtf8Lenient s
+    in \t -> unsafePerformIO
+        $ handle @SomeException (const $ pure False) $ evaluate
+        $ matchesOpt Caseless p (decodeUtf8Lenient t)
+-}
+
+-- regex-posix version (reputed to be slow and buggy)
+matches s = case makeRegexOptsM compIgnoreCase 0 s of
+    Just p -> match p
+    _      -> const False
+
+-- not yet tried:
+-- regex-tdfa (mass Text conversion, parsec dep) text import
+-- regex-dfa (not in Stackage, unknown engine)
 

--- a/Base.hs
+++ b/Base.hs
@@ -71,7 +71,7 @@ matches s = case makeRegexOptsM compCaseless 0 s of
 -}
 
 {-
--- pcre2 version (inefficient, mass Text conversion)
+-- pcre2 version (inefficient, mass Text conversion, ugly)
 -- needs text dep/import
 matches s =
     let p = decodeUtf8Lenient s

--- a/Base.hs
+++ b/Base.hs
@@ -30,7 +30,7 @@ import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X
 import Text.Printf as X
 import Text.Read as X (readMaybe)
-import Text.Regex.Posix (match, makeRegexOptsM, compIgnoreCase)
+import Text.Regex.Posix (match, makeRegexOptsM, compIgnoreCase, compExtended)
 
 import System.Clock
 
@@ -81,9 +81,8 @@ matches s =
 -}
 
 -- regex-posix version (reputed to be slow and buggy)
-matches s = case makeRegexOptsM compIgnoreCase 0 s of
-    Just p -> match p
-    _      -> const False
+matches s = maybe (const False) match $
+    makeRegexOptsM (compIgnoreCase + compExtended) 0 s
 
 -- not yet tried:
 -- regex-tdfa (mass Text conversion, parsec dep) text import

--- a/Base.hs
+++ b/Base.hs
@@ -21,6 +21,7 @@ import Data.List as X hiding ((!?))
 import Data.Maybe as X
 import Data.Sequence as X (Seq, (<|), (|>))
 import Data.String as X
+import Data.Text.Encoding (decodeUtf8Lenient)
 import Data.Traversable as X
 import Data.Version as X
 import Data.Void as X
@@ -30,7 +31,7 @@ import System.IO as X (Handle, hClose)
 import System.IO.Unsafe as X
 import Text.Printf as X
 import Text.Read as X (readMaybe)
-import Text.Regex.PCRE2 (compCaseless, match, makeRegexOptsM)
+import Text.Regex.Pcre2 (matchesOpt, Option(Caseless))
 
 import System.Clock
 
@@ -63,9 +64,15 @@ matches s = case compileM s [caseless, utf8] of
     _       -> const False
 -}
 
--- regex-pcre2 version
+{-
+-- regex-pcre2 version (fails to build in CI, not in Stackage)
 matches s = case makeRegexOptsM compCaseless 0 s of
     Just p -> match p
     _      -> const False
+-}
 
+-- pcre2 version (highly inefficient, mass Text conversion)
+matches s t = unsafePerformIO
+    $ handle @SomeException (const $ pure False) $ evaluate
+    $ matchesOpt Caseless (decodeUtf8Lenient s) (decodeUtf8Lenient t)
 

--- a/Core.hs
+++ b/Core.hs
@@ -48,8 +48,6 @@ import System.Posix.FilePath    (takeFileName)
 
 import System.Posix.Process     (exitImmediately)
 
-import Text.Regex.PCRE.Light
-
 
 mp3Tool :: String
 mp3Tool = "mpg123"
@@ -470,18 +468,15 @@ genericJumpToMatch :: Lookup a
                    -> IO ()
 genericJumpToMatch re sw k sel = do
     found <- modifyHS \st -> let
-        mdata = case re of
+        info = case re of
             Just s -> Just (st { searchFw = sw }, s, sw)
             _      -> listToMaybe [ (st, s, searchFw st == sw) | s <- searchHist st ]
-        mre = mdata >>= \ (st', s, sw') ->
-            case compileM (P.pack s) [caseless, utf8] of
-                Right p -> Just (st', p, sw')
-                Left _  -> Nothing
-        in flip (maybe (st, False)) mre \(st', p, forwards) -> do
+        in flip (maybe (st, False)) info \(st', p, forwards) -> do
             let (fs, cur, m) = k st
-                l = if forwards then [cur+1..m-1] ++ [0..cur]
-                                else [cur-1,cur-2..0] ++ [m-1,m-2..cur]
-            case [ i | i <- l, isJust $ match p (extract (fs ! i)) [] ] of
+                l = if forwards then [cur+1 .. m-1] ++ [0 .. cur]
+                                else [cur-1, cur-2 .. 0] ++ [m-1, m-2 .. cur]
+                match = matches (P.pack p)
+            case [ i | i <- l, match $ extract (fs ! i) ] of
                 i:_ -> (st' { cursor = sel i st }, True)
                 _   -> (st', False)
     unless found $ putMessage $ Fast "No match found." defaultSty

--- a/Core.hs
+++ b/Core.hs
@@ -104,10 +104,10 @@ start opts (Playlist folders music) = do
         , clock        = Nothing
         , info         = Nothing
         , id3          = Nothing
-        , regex        = Nothing
         , modal        = Nothing
         , playHist     = mempty
         , searchHist   = []
+        , searchFw     = True
         , histSize     = optHistSize opts
         , miniFocused  = False
         , exiting      = False
@@ -470,11 +470,13 @@ genericJumpToMatch :: Lookup a
                    -> IO ()
 genericJumpToMatch re sw k sel = do
     found <- modifyHS \st -> let
-        mre = case re of
-            Nothing -> (\(r, d) -> (st, r, d == sw)) <$> regex st
-            Just s  -> case compileM (P.pack s) [caseless, utf8] of
-                Left _      -> Nothing
-                Right v     -> Just (st { regex = Just (v, sw) }, v, sw)
+        mdata = case re of
+            Just s -> Just (st { searchFw = sw }, s, sw)
+            _      -> listToMaybe [ (st, s, searchFw st == sw) | s <- searchHist st ]
+        mre = mdata >>= \ (st', s, sw') ->
+            case compileM (P.pack s) [caseless, utf8] of
+                Right p -> Just (st', p, sw')
+                Left _  -> Nothing
         in flip (maybe (st, False)) mre \(st', p, forwards) -> do
             let (fs, cur, m) = k st
                 l = if forwards then [cur+1..m-1] ++ [0..cur]

--- a/State.hs
+++ b/State.hs
@@ -18,7 +18,6 @@ import System.Clock             (TimeSpec(..))
 import System.IO                (hFlush)
 import System.Process           (ProcessHandle)
 import System.Random            (StdGen)
-import Text.Regex.PCRE.Light    (Regex)
 
 
 -- | Player state
@@ -45,7 +44,7 @@ data HState = HState
     , miniFocused     :: !Bool                 -- is the mini buffer focused?
     , mode            :: !Mode
     , uptime          :: !ByteString
-    , regex           :: !(Maybe (Regex,Bool)) -- most recent search pattern and direction
+    , searchFw        :: !Bool                 -- active search direction
     , searchHist      :: ![String]
     , exiting         :: !Bool                 -- let mpg123 die?
     , playHist        :: !(Seq (TimeSpec, Int))

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -74,7 +74,7 @@ library
     filepath,
     hscurses,
     mtl,
-    pcre2 >=2.3,
+    pcre2 >=2.2,
     posix-paths,
     process,
     random,

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -74,11 +74,10 @@ library
     filepath,
     hscurses,
     mtl,
-    pcre2 >=2.2,
     posix-paths,
     process,
     random,
-    text,
+    regex-posix,
     unix >=2.8,
     utf8-string,
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -99,6 +99,7 @@ test-suite test
   main-is: Main.hs
   hs-source-dirs: test
   other-modules:
+    BaseSpec
     ConfigSpec
     CoreSpec
     DecoderSpec

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -74,10 +74,11 @@ library
     filepath,
     hscurses,
     mtl,
-    regex-pcre2 >=1,
+    pcre2 >=2.3,
     posix-paths,
     process,
     random,
+    text,
     unix >=2.8,
     utf8-string,
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -74,7 +74,7 @@ library
     filepath,
     hscurses,
     mtl,
-    pcre-light >=0.3,
+    regex-pcre2 >=1,
     posix-paths,
     process,
     random,

--- a/test/BaseSpec.hs
+++ b/test/BaseSpec.hs
@@ -1,0 +1,30 @@
+module BaseSpec (tests) where
+
+import Data.ByteString.UTF8 qualified as UTF8
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Base (matches)
+
+tests :: TestTree
+tests = testGroup "Base"
+    [ testGroup "match"
+        [ t True "exact"         "foo"       "fooBar"
+        , t True "caseless"      "FOO"       "fooBar"
+        , t False "invalid"      "["         "any[thing"
+        , t True "alt"           "(foo|az)Q" "bazQux"
+        , t True "dot"           "o.a"       "foobar"
+        , t True "Unicode"       "jör"       "Björk"
+        , t True "dot Unicode"   "j.r"       "Björk"
+        , t True "Nordic case"   "bør"       "BØrnE"
+        , t True "Greek case"    "Λω"        "ΦλΩα"
+        , t True "dot CJK"       "中.人"     "中國人"
+        ]
+    ]
+
+
+t :: Bool -> String -> String -> String -> TestTree
+t b tag pat str =
+    testCase tag $ matches (UTF8.fromString pat) (UTF8.fromString str) @?= b
+

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Tasty
 
+import BaseSpec qualified
 import ConfigSpec qualified
 import CoreSpec qualified
 import DecoderSpec qualified
@@ -11,7 +12,8 @@ import WidthSpec qualified
 
 main :: IO ()
 main = defaultMain $ testGroup "hmp3-ng"
-    [ ConfigSpec.tests
+    [ BaseSpec.tests
+    , ConfigSpec.tests
     , CoreSpec.tests
     , DecoderSpec.tests
     , StyleSpec.tests


### PR DESCRIPTION
The hope is that this closes #138.

As discussed in that issue, `pcre` (version 1; aka `pcre3` for reasons) is no longer a viable dependency.  Indeed, hmp3-ng cannot be built atop many existing distros, which is really bad.  The replacement is `pcre2`.  However, `pcre-light`, which we are using, is stuck on the old `pcre`.  An [issue was opened](https://codeberg.org/daniel-casanueva/pcre-light/issues/19) three weeks ago to switch, but it is not yet addressed, and it may never be; the migration might not be simple.  Thus, I need an alternative.  However, I'm facing the usual problem that Hackage is filled with outdated, incomplete packages.

My first order of business was to refactor to make swapping back ends easier.  One chore, which I've been meaning to do anyway, is to move the cache of the last regex out of the HState; after all, we've had a search history feature for over 5 years (ccd42bb).  This removes a usage, and also removes the oddness mentioned in https://github.com/galenhuntington/hmp3-ng/issues/73#issuecomment-4701618204.  For another, there's only one thing the app needs to do with a regex library—ask if a string matches a pattern—and this can be factored as a single function providing this service.  Partial application allows compiling the pattern once (when the library supports it).  With this, I am able to try alternatives, and can return to `pcre-light` if it gets its upgrade.

That done, my skim of Hackage for current (not abandoned) `pcre2` packages yielded two candidates:

*  `regex-pcre2`.  This is confirmed to work locally, but is not without problems.  For one, it's not in Stackage.  For another, CI fails with C compilation errors, e.g., `Wrap.hsc:369:84: error: ‘PCRE2_ALT_EXTENDED_CLASS’ undeclared`.  No idea what this is about, maybe a version mismatch.  Even if I could fix it today, it might be a constant fight to keep it working.
*  `pcre2`.  This works but is very awkward to use and inefficient.  For one, it only accepts Text, so we'd have to convert.  (That said, the case for ByteStrings everywhere might weaken; related: #97.)  For another, it doesn't seem to offer a compilation function, so the pattern is recompiled each match.  An invalid pattern might be thousands of throws and catches (although I could add an error pre-check I suppose; indeed, many of these layer functions could probably be optimized if I decided to stick with a package).

There is a third alternative:

*  Call libpcre2 myself with the FFI.  My needs are modest—I just need a boolean true or false, not capture groups and so on—so this may not be that bad.  Still, I'd much prefer to delegate to a maintained library.

In short, not a great scene.

I'm not wedded to PCRE.  This is only a feature for users to conveniently find songs.  We don't need a superpowered industrial-grade regex engine.  I'd like something better than `isInfixOf`, but I'm not picky.  That said, the Hackage ecosystem problems might be expected to equally affect alternatives.

I considered these:

*  `regex-tdfa`.  Seems to be the favored go-to?  But it pulls in `parsec` and requires conversion to Text (there is a ByteString variant, but it's ASCII-only).
*  `regex-posix`.  Advertised as a lightweight alternative.  The Haskell wiki [warns](https://wiki.haskell.org/Regex_Posix) that it's terrible: buggy, very slow, best avoided in favor of the previous.
*  `regex-dfa`.  I don't know anything about the engine.  It's not in Stackage.  Didn't look further.

Of these three, I only tried `regex-posix`.  It seems to come out ahead.  The bugs described in the wiki all look like edge cases with matched strings and captures, which aren't relevant to my needs.  The slowness probably is exaggerated and may refer to pathological patterns, and "very slow" might mean a few milliseconds to search a list of thousands.

Moreover, it's working perfectly.  CI passes on every Ubuntu available, and even on Mac, with no fuss or special casing.  (There's even a Windows compatibility shim in Hackage, though I didn't test it and am not looking to support it.)  It seems featureful enough.  It handled Unicode correctly in my few manual tests (and maybe tests can be written).

So, I'm tentatively going with it.  I will also ask Claude Code's opinion.