### PR TITLE
Correct search typing and backspace.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -56,10 +56,10 @@ matches s = maybe (const False) match $
     makeRegexOptsM (compIgnoreCase + compExtended) 0 s
 
 -- | Zipper structure, representing a list with a cursor.
-data Zipper a = Zipper { cur :: !a, back :: ![a], front :: ![a] }
+data Zipper a = Zipper { zipperCur :: !a, zipperBack :: ![a], zipperFront :: ![a] }
 
 zipEdit :: (a -> a) -> Zipper a -> Zipper a
-zipEdit f z = z { cur = f (cur z) }
+zipEdit f z = z { zipperCur = f (zipperCur z) }
 
 zipUp, zipDown :: Zipper a -> Zipper a
 zipUp   (Zipper c (nx:rest) f)  = Zipper nx rest (c:f)

--- a/Base.hs
+++ b/Base.hs
@@ -55,3 +55,15 @@ matches :: ByteString -> ByteString -> Bool
 matches s = maybe (const False) match $
     makeRegexOptsM (compIgnoreCase + compExtended) 0 s
 
+-- | Zipper structure, representing a list with a cursor.
+data Zipper a = Zipper { cur :: !a, back :: ![a], front :: ![a] }
+
+zipEdit :: (a -> a) -> Zipper a -> Zipper a
+zipEdit f z = z { cur = f (cur z) }
+
+zipUp, zipDown :: Zipper a -> Zipper a
+zipUp   (Zipper c (nx:rest) f)  = Zipper nx rest (c:f)
+zipUp   z                       = z
+zipDown (Zipper c b (pv:rest))  = Zipper pv (c:b) rest
+zipDown z                       = z
+

--- a/Core.hs
+++ b/Core.hs
@@ -450,18 +450,18 @@ class Lookup a       where extract :: a -> RawFilePath
 instance Lookup Dir  where extract = takeFileName . dname
 instance Lookup File where extract = fbase
 
-jumpToMatchFile :: Maybe String -> Bool -> IO ()
+jumpToMatchFile :: Maybe ByteString -> Bool -> IO ()
 jumpToMatchFile re sw = genericJumpToMatch re sw k sel
     where k st = (music st, cursor st, size st)
           sel i _ = i
 
-jumpToMatchDir :: Maybe String -> Bool -> IO ()
+jumpToMatchDir :: Maybe ByteString -> Bool -> IO ()
 jumpToMatchDir re sw = genericJumpToMatch re sw k sel
     where k st = (folders st, fdir (music st ! cursor st), length $ folders st)
           sel i st = dlo (folders st ! i)
 
 genericJumpToMatch :: Lookup a
-                   => Maybe String
+                   => Maybe ByteString
                    -> Bool
                    -> (HState -> (Array Int a, Int, Int))
                    -> (Int -> HState -> Int)
@@ -475,7 +475,7 @@ genericJumpToMatch re sw k sel = do
             let (fs, cur, m) = k st
                 l = if forwards then [cur+1 .. m-1] ++ [0 .. cur]
                                 else [cur-1, cur-2 .. 0] ++ [m-1, m-2 .. cur]
-                match = matches (P.pack p)
+                match = matches p
             case [ i | i <- l, match $ extract (fs ! i) ] of
                 i:_ -> (st' { cursor = sel i st }, True)
                 _   -> (st', False)

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -10,7 +10,7 @@
 -- transitions (entering search, popping up the song-history modal,
 -- confirming a quit) are just "return a different 'KeyMap'."
 --
-module Keymap (keyLoop, keyTable, unkey, charToKey) where
+module Keymap (keyLoop, keyTable, unkey, charToKey, dropLastUTF8) where
 
 import Base
 
@@ -76,12 +76,7 @@ historyKeyMap = M.fromList $ zip (toList historyKeys) [0..]
 ------------------------------------------------------------------------
 -- Search mode
 
--- | Zipper over the search-history list, with the currently edited
--- string in the focus.  'back' holds older entries we can step back
--- to (Up); 'front' holds entries we've stepped back from (Down).
-data Zipper = Zipper { cur :: !String, _back :: ![String], _front :: ![String] }
-
-searchMode :: Char -> Zipper -> IO KeyMap
+searchMode :: Char -> Zipper ByteString -> IO KeyMap
 searchMode stype = step where
     step z = renderSearch stype z $> KeyMap (`dispatch` z)
 
@@ -89,16 +84,16 @@ searchMode stype = step where
         | c `elem` ['\ESC', '\^C']
                            = clearMessage *> leave
         | c `elem` enter'  = commit z
-        | c `elem` delete' = step $ zipEdit dropLast z
+        | c `elem` delete' = step $ zipEdit dropLastUTF8 z
         | k == KeyUp       = step $ zipUp z
         | k == KeyDown     = step $ zipDown z
         | k == KeyDC       = histDelete z
         | c < ' ' || c > '\255'
                            = step z   -- ignore other special keys
-        | otherwise        = step $ zipEdit (++ [c]) z
+        | otherwise        = step $ zipEdit (`P.snoc` c) z
       where k = charToKey c
 
-    commit (Zipper []  _ _) = clearMessage *> leave
+    commit (Zipper ""  _ _) = clearMessage *> leave
     commit (Zipper pat _ _) = do
         let jumpy = if stype `elem` ['/', '?']
                     then jumpToMatchFile else jumpToMatchDir
@@ -115,21 +110,12 @@ searchMode stype = step where
 
     leave = toggleFocus $> mainMode
 
-renderSearch :: Char -> Zipper -> IO ()
-renderSearch prefix z = putMessage $ Fast (P.pack (prefix : cur z)) defaultSty
+renderSearch :: Char -> Zipper ByteString -> IO ()
+renderSearch prefix z = putMessage $ Fast (prefix `P.cons` cur z) defaultSty
 
-dropLast :: [a] -> [a]
-dropLast [] = []
-dropLast xs = init xs
-
-zipEdit :: (String -> String) -> Zipper -> Zipper
-zipEdit f z = z { cur = f (cur z) }
-
-zipUp, zipDown :: Zipper -> Zipper
-zipUp   (Zipper c (nx:rest) f)  = Zipper nx rest (c:f)
-zipUp   z                       = z
-zipDown (Zipper c b (pv:rest))  = Zipper pv (c:b) rest
-zipDown z                       = z
+dropLastUTF8 :: ByteString -> ByteString
+dropLastUTF8 = P.dropEnd 1 . P.dropWhileEnd isCC
+    where isCC b = b >= '\128' && b < '\192'
 
 enter', delete' :: [Char]
 enter'  = ['\n', '\r']

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -105,13 +105,13 @@ searchMode stype = step where
         let z' = case z of
                 Zipper _ b (pv:rest) -> Zipper pv b rest
                 Zipper _ b _         -> Zipper "" b []
-        modifyHS_ \st -> st { searchHist = filter (/= cur z) (searchHist st) }
+        modifyHS_ \st -> st { searchHist = filter (/= zipperCur z) (searchHist st) }
         step z'
 
     leave = toggleFocus $> mainMode
 
 renderSearch :: Char -> Zipper ByteString -> IO ()
-renderSearch prefix z = putMessage $ Fast (prefix `P.cons` cur z) defaultSty
+renderSearch prefix z = putMessage $ Fast (prefix `P.cons` zipperCur z) defaultSty
 
 dropLastUTF8 :: ByteString -> ByteString
 dropLastUTF8 = P.dropEnd 1 . P.dropWhileEnd isCC

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -114,8 +114,8 @@ renderSearch :: Char -> Zipper ByteString -> IO ()
 renderSearch prefix z = putMessage $ Fast (prefix `P.cons` zipperCur z) defaultSty
 
 dropLastUTF8 :: ByteString -> ByteString
-dropLastUTF8 = P.dropEnd 1 . P.dropWhileEnd isCC
-    where isCC b = b >= '\128' && b < '\192'
+dropLastUTF8 = P.dropEnd 1 . P.dropWhileEnd isCB
+    where isCB b = b >= '\128' && b < '\192'
 
 enter', delete' :: [Char]
 enter'  = ['\n', '\r']

--- a/State.hs
+++ b/State.hs
@@ -45,7 +45,7 @@ data HState = HState
     , mode            :: !Mode
     , uptime          :: !ByteString
     , searchFw        :: !Bool                 -- active search direction
-    , searchHist      :: ![String]
+    , searchHist      :: ![ByteString]
     , exiting         :: !Bool                 -- let mpg123 die?
     , playHist        :: !(Seq (TimeSpec, Int))
     , histSize        :: Int

--- a/UI.hs
+++ b/UI.hs
@@ -15,7 +15,9 @@ module UI (
     -- * Construction, destruction
     start, end, screenSize, refresh, refreshClock, resetui,
     -- * Input
-    getKey
+    getKey,
+    -- * Tool
+    u,
   ) where
 
 import Base

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -103,6 +103,7 @@ test-suite test
     ConfigSpec
     CoreSpec
     DecoderSpec
+    KeymapSpec
     PlaylistSpec
     StyleSpec
     WidthSpec

--- a/test/BaseSpec.hs
+++ b/test/BaseSpec.hs
@@ -3,9 +3,8 @@ module BaseSpec (tests) where
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.ByteString.UTF8 qualified as UTF8
-
 import Base (matches)
+import UI (u)
 
 tests :: TestTree
 tests = testGroup "Base"
@@ -25,6 +24,5 @@ tests = testGroup "Base"
 
 
 m :: Bool -> String -> String -> String -> TestTree
-m b tag pat str =
-    testCase tag $ matches (UTF8.fromString pat) (UTF8.fromString str) @?= b
+m b tag pat str = testCase tag $ matches (u pat) (u str) @?= b
 

--- a/test/KeymapSpec.hs
+++ b/test/KeymapSpec.hs
@@ -1,0 +1,18 @@
+module KeymapSpec (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Keymap (dropLastUTF8)
+import UI (u)
+
+tests :: TestTree
+tests = testGroup "Keymap"
+    [ testGroup "dropLastUtf8"
+        [ testCase "ASCII"  $ dropLastUTF8 "abc"         @?= "ab"
+        , testCase "French" $ dropLastUTF8 (u"été")      @?= u"ét"
+        , testCase "CJK"    $ dropLastUTF8 (u"中國")     @?= u"中"
+        , testCase "Emoji"  $ dropLastUTF8 (u"Yes👍")    @?= u"Yes"
+        ]
+    ]
+

--- a/test/KeymapSpec.hs
+++ b/test/KeymapSpec.hs
@@ -8,11 +8,13 @@ import UI (u)
 
 tests :: TestTree
 tests = testGroup "Keymap"
-    [ testGroup "dropLastUtf8"
-        [ testCase "ASCII"  $ dropLastUTF8 "abc"         @?= "ab"
-        , testCase "French" $ dropLastUTF8 (u"été")      @?= u"ét"
-        , testCase "CJK"    $ dropLastUTF8 (u"中國")     @?= u"中"
-        , testCase "Emoji"  $ dropLastUTF8 (u"Yes👍")    @?= u"Yes"
+    [ testGroup "dropLastUTF8"
+        [ testCase "ASCII"    $ dropLastUTF8 "abc"          @?= "ab"
+        , testCase "empty"    $ dropLastUTF8 ""             @?= ""
+        , testCase "French"   $ dropLastUTF8 (u"été")       @?= u"ét"
+        , testCase "CJK"      $ dropLastUTF8 (u"中國")      @?= u"中"
+        , testCase "Emoji"    $ dropLastUTF8 (u"Yes👍")     @?= u"Yes"
+        , testCase "invalid"  $ dropLastUTF8 "\x80"         @?= ""
         ]
     ]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import BaseSpec qualified
 import ConfigSpec qualified
 import CoreSpec qualified
 import DecoderSpec qualified
+import KeymapSpec qualified
 import PlaylistSpec qualified
 import StyleSpec qualified
 import WidthSpec qualified
@@ -16,6 +17,7 @@ main = defaultMain $ testGroup "hmp3-ng"
     , ConfigSpec.tests
     , CoreSpec.tests
     , DecoderSpec.tests
+    , KeymapSpec.tests
     , StyleSpec.tests
     , PlaylistSpec.tests
     , WidthSpec.tests

--- a/test/WidthSpec.hs
+++ b/test/WidthSpec.hs
@@ -3,12 +3,10 @@ module WidthSpec (tests) where
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.ByteString (ByteString)
-import Data.ByteString.UTF8 qualified as UTF8
-
 import Width (displayWidth, toMaxWidth, toWidth)
+import UI (u)
 
--- These tests depend on wcwidth's behaviour under a UTF-8 locale and on a
+-- These tests depend on wcwidth's behavior under a UTF-8 locale and on a
 -- handful of codepoints whose canonical widths are well-known:
 --   * ASCII chars are 1 column.
 --   * Latin-Extended chars (é, ñ) are 1 column.
@@ -55,11 +53,9 @@ tests = testGroup "Width"
         , testCase "exact width unchanged"
             $ toWidth 5 "hello"        @?= "hello"
         , testCase "truncate matches toMaxWidth when over-width"
-            $ toWidth 4 "hello"        @?= "hel" <> u"…"
+            $ toWidth 4 "hello"        @?= u"hel…"
         , testCase "pads after a wide-char content too"
-            $ toWidth 5 (u "中a")      @?= u"中a" <> "  "
+            $ toWidth 5 (u"中a")       @?= u"中a  "
         ]
     ]
 
-u :: String -> ByteString
-u = UTF8.fromString


### PR DESCRIPTION
The search string has been stored as a String even though it's actually a list of bytes in Char clothing.  When keyboard keys come through, they are a bit like Chars with special codes, but Unicode characters that are composed or pasted come through as a sequence of UTF-8 bytes (this from testing in my terminal).  But they were getting appended to the search string like characters on a String.

This PR changes search strings to be ByteStrings, which correctly captures their semantics.  I left the type of the single translated key as a Char, since I don't know what else to type it as, and it's convenient to compare to, e.g., `'q'` (and there is no OverloadedChars extension).  This may be technically incorrect but it's of limited reach.

A related bug is that backspace inside a search was deleting the last byte, when it should be last codepoint.  I actually observed this issue in practice.  This is fixed by iterating backwards from the end past continuation bytes.  (There is no `Data.ByteString.UTF8.unsnoc`, though there certainly could be.)  Tests are added.

There's minor other rearrangement and changes.  Notably, I generalized Zipper.  For example, I may later want something like a zipper for the search string itself to support editing with left/right arrow keys.