### PR TITLE
Aim to systematically fix deadlocks under various failure modes.

### DIFF
--- a/Base.hs
+++ b/Base.hs
@@ -13,6 +13,7 @@ import Control.Exception as X
 import Control.Monad as X
 import Data.ByteString as X (ByteString)
 import Data.Char as X
+import Data.Either as X
 import Data.Fixed as X
 import Data.Foldable as X
 import Data.Functor as X hiding (unzip)

--- a/Core.hs
+++ b/Core.hs
@@ -139,12 +139,7 @@ exitTime e | is @IOException Proxy e = False -- ignore
 
 ------------------------------------------------------------------------
 
--- | Process loop, launch mpg123, set the handles in the state
--- and then wait for the process to die. If it does, restart it.
---
--- If we're unable to start at all, we should say something sensible
--- For example, if we can't start it two times in a row, perhaps give up?
---
+-- | Loop, launching decoder and updating global state.
 mpgLoop :: IO ()
 mpgLoop = runForever do
 
@@ -191,7 +186,7 @@ mpgLoop = runForever do
     -- Slow spawn loops in case of trouble.
     threadDelay 4_000_000
 
-
+-- | Timestamp for spawn errors
 timeString :: IO String
 timeString = take 19 . show <$> (utcToLocalZonedTime =<< getCurrentTime)
 
@@ -201,7 +196,6 @@ timeString = take 19 . show <$> (utcToLocalZonedTime =<< getCurrentTime)
 -- for it to be modified again.
 refreshLoop :: IO ()
 refreshLoop = runForever $ takeMVar modified *> UI.refresh
-
 
 ------------------------------------------------------------------------
 
@@ -235,9 +229,7 @@ showTimeDiff = showTimeDiff_ False
 ------------------------------------------------------------------------
 
 -- | Handle messages arriving over a pipe from the decoder process. When
--- shutdown kills the other end of the pipe, hGetLine will fail, so we
--- take that chance to exit.
---
+-- shutdown kills the other end of the pipe, hGetLine will fail.
 mpgInput :: IO ()
 mpgInput = runForever $ do
     line <- P.hGetLine =<< errh <$> readMVar mpg
@@ -262,10 +254,8 @@ shutdown ms = do
         _      -> pure ExitSuccess
 
 ------------------------------------------------------------------------
--- 
--- Write incoming messages from the encoder to the global state in the
--- right pigeon hole.
---
+-- Process incoming messages from the decoder.
+
 handleMsg :: Msg -> IO ()
 
 handleMsg (S i)   = modifyHS_ $ \s -> s { info = Just i }
@@ -281,9 +271,7 @@ handleMsg (F f) = do
     UI.refreshClock
 
 ------------------------------------------------------------------------
---
 -- Basic operations
---
 
 -- | Seek backward in song
 seekLeft :: IO ()

--- a/Core.hs
+++ b/Core.hs
@@ -35,7 +35,9 @@ import Data.Sequence qualified as Seq
 
 import Data.Array               ((!), Array)
 import Data.Proxy
+import Data.Time
 import Data.Tuple               (swap)
+import Control.Monad.Except
 import Control.Monad.State.Strict
 import System.Directory         (doesFileExist, findExecutable, createDirectoryIfMissing,
                                  getXdgDirectory, XdgDirectory(..))
@@ -45,12 +47,8 @@ import System.Clock             (TimeSpec(..), diffTimeSpec)
 import System.Random            (randomR, newStdGen)
 import System.FilePath          ((</>))
 import System.Posix.FilePath    (takeFileName)
-
 import System.Posix.Process     (exitImmediately)
 
-
-mp3Tool :: String
-mp3Tool = "mpg123"
 
 ------------------------------------------------------------------------
 
@@ -149,17 +147,27 @@ exitTime e | is @IOException Proxy e = False -- ignore
 --
 mpgLoop :: IO ()
 mpgLoop = runForever do
-    mmpg <- findExecutable mp3Tool
-    case mmpg of
-      Nothing     -> shutdown $ Just $ "Cannot find " ++ mp3Tool ++ " in path"
-      Just mppath -> do
-        mv <- try $ runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing
-        case mv of
-          Left (ex :: SomeException) ->
-            warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
-          Right (writeh, _, errh, ph) -> do
+    empg <- runExceptT do
+        mppath <- join $
+            maybe (throwError $ "Cannot find " ++ mp3Tool ++ " in path") pure
+            <$> lift (findExecutable mp3Tool)
+        join $ either
+            (\ex -> throwError $ mp3Tool ++ " failed to start; retrying: " ++ show ex)
+            pure
+            <$> lift (try @SomeException
+                (runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing))
 
+    case empg of
+
+        Left err -> do
+            now <- timeString
+            warnA $ err ++ " (" ++ now ++ ")"
+            -- Hackily count failed initial spawn, for Ready message
+            silentlyModifyHS \st -> st { spawns = spawns st `max` 1 }
+            threadDelay 20_000_000  -- longer wait after these errors
+
+        Right (writeh, _, errh, ph) -> do
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { status    = Stopped
                 , info      = Nothing
@@ -178,11 +186,14 @@ mpgLoop = runForever do
             void $ takeMVar mpg
 
             threadDelay 1_000_000  -- let threads spit errors
-            warnA $ "Restarting " ++ mppath ++ " ..."
+            warnA $ "Restarting " ++ mp3Tool ++ " ..."
 
-        -- Slow spawn loops in case of trouble.
-        threadDelay 4_000_000
+    -- Slow spawn loops in case of trouble.
+    threadDelay 4_000_000
 
+
+timeString :: IO String
+timeString = take 19 . show <$> (utcToLocalZonedTime =<< getCurrentTime)
 
 ------------------------------------------------------------------------
 
@@ -232,7 +243,7 @@ mpgInput = runForever $ do
     line <- P.hGetLine =<< errh <$> readMVar mpg
     case mpgParser line of
         Right m       -> handleMsg m
-        Left (Just e) -> warnA ("mpg123: " ++ e)
+        Left (Just e) -> warnA (mp3Tool ++ ": " ++ e)
         _             -> pure ()
 
 ------------------------------------------------------------------------

--- a/Core.hs
+++ b/Core.hs
@@ -205,7 +205,7 @@ showTimeDiff = showTimeDiff_ False
 -- shutdown kills the other end of the pipe, hGetLine will fail.
 mpgInput :: IO ()
 mpgInput = runForever $ do
-    line <- P.hGetLine =<< errh <$> readMVar mpg
+    line <- P.hGetLine =<< readMVar mpgRead
     case mpgParser line of
         Right m       -> handleMsg m
         Left (Just e) -> warnA (mp3Tool ++ ": " ++ e)
@@ -217,12 +217,11 @@ mpgInput = runForever $ do
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
     UI.end
-    mph <- readIORef mpgProcess
-    whenJust mph \ph -> do
+    mpg <- readIORef mpgRef
+    whenJust mpg \Mpg { mpgPH } -> do
         discardErrors writeState
-        discardErrors do
-            sendMpg Quit
-            void $ waitForProcess ph
+        void $ sendMpg' Quit
+        void $ waitForProcess mpgPH
     exitImmediately =<< case ms of
         Just s -> hPutStrLn stderr s *> pure (ExitFailure 1)
         _      -> pure ExitSuccess

--- a/Core.hs
+++ b/Core.hs
@@ -144,14 +144,12 @@ mpgLoop :: IO ()
 mpgLoop = runForever do
 
     empg <- runExceptT do
-        mppath <- join $
+        mppath <- lift (findExecutable mp3Tool) >>=
             maybe (throwError $ "Cannot find " ++ mp3Tool ++ " in path") pure
-            <$> lift (findExecutable mp3Tool)
-        join $ either
-            (\ex -> throwError $ mp3Tool ++ " failed to start; retrying: " ++ show ex)
-            pure
-            <$> lift (try @SomeException
-                (runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing))
+        lift (try @SomeException $
+            runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing
+            ) >>= flip either pure \ex ->
+                throwError $ mp3Tool ++ " failed to start; retrying: " ++ show ex
 
     case empg of
 

--- a/Core.hs
+++ b/Core.hs
@@ -137,7 +137,6 @@ exitTime e | is @IOException Proxy e = False -- ignore
 -- | Loop, launching decoder and updating global state.
 mpgLoop :: IO ()
 mpgLoop = runForever do
-
     empg <- runExceptT do
         mppath <- lift (findExecutable mp3Tool) >>=
             maybe (throwError $ "Cannot find " ++ mp3Tool ++ " in path") pure
@@ -145,38 +144,24 @@ mpgLoop = runForever do
             runInteractiveProcess mppath ["-R", "--remote-err"] Nothing Nothing
             ) >>= flip either pure \ex ->
                 throwError $ mp3Tool ++ " failed to start; retrying: " ++ show ex
-
     case empg of
-
         Left err -> do
             warnA err
             -- Hackily count failed initial spawn, for Ready message
             silentlyModifyHS \st -> st { spawns = spawns st `max` 1 }
             threadDelay 20_000_000  -- longer wait after these errors
-
-        Right (writeh, _, errh, ph) -> do
+        Right handles -> do
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
                 { status    = Stopped
                 , info      = Nothing
                 , id3       = Nothing
                 , spawns    = sp
                 }, sp)
-
-            putMVar mpg Mpg { errh, writeh }
-            writeIORef mpgProcess $ Just ph
-
             when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
-            catch @SomeException (void $ waitForProcess ph) (const $ pure ())
-
-            -- Must be in this order or risk shutdown deadlock!
-            writeIORef mpgProcess Nothing
-            void $ takeMVar mpg
-
+            overseeMpg handles
             threadDelay 1_000_000  -- let threads spit errors
             warnA $ "Restarting " ++ mp3Tool ++ " ..."
-
-    -- Slow spawn loops in case of trouble.
-    threadDelay 4_000_000
+    threadDelay 4_000_000  -- rate-limit respawns
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -98,7 +98,6 @@ start opts (Playlist folders music) = do
         , config
         , threads
         , spawns       = 0
-        , mpgPid       = Nothing
         , clock        = Nothing
         , info         = Nothing
         , id3          = Nothing
@@ -160,22 +159,23 @@ mpgLoop = runForever do
           Left (ex :: SomeException) ->
             warnA $ mppath ++ " failed to start; retrying: " ++ show ex
 
-          Right (writeh, _, errh, pid) -> do
+          Right (writeh, _, errh, ph) -> do
+
             ct <- modifyHS $ \st -> let sp = spawns st + 1 in (st
-                { mpgPid    = Just pid
-                , status    = Stopped
+                { status    = Stopped
                 , info      = Nothing
                 , id3       = Nothing
                 , spawns    = sp
                 }, sp)
 
             putMVar mpg Mpg { errh, writeh }
+            writeIORef mpgProcess $ Just ph
 
             when (ct > 1) $ warnA $ mp3Tool ++ " #" ++ show ct ++ ": Ready"
-            catch @SomeException (void $ waitForProcess pid) (const $ pure ())
+            catch @SomeException (void $ waitForProcess ph) (const $ pure ())
 
             -- Must be in this order or risk shutdown deadlock!
-            silentlyModifyHS $ \st -> st { mpgPid = Nothing }
+            writeIORef mpgProcess Nothing
             void $ takeMVar mpg
 
             stop <- getsHS exiting
@@ -241,16 +241,15 @@ mpgInput = runForever $ do
 ------------------------------------------------------------------------
 
 -- | Close most things. Important to do all the jobs:
--- TODO maybe releaseSignals here?
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
     UI.end
     silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState
-    mpid <- getsHS mpgPid
-    whenJust mpid \pid -> do
+    mph <- readIORef mpgProcess
+    whenJust mph \ph -> do
         discardErrors $ sendMpg Quit
-        void $ waitForProcess pid
+        void $ waitForProcess ph
     exitImmediately =<< case ms of
         Just s -> hPutStrLn stderr s *> pure (ExitFailure 1)
         _      -> pure ExitSuccess

--- a/Core.hs
+++ b/Core.hs
@@ -107,7 +107,6 @@ start opts (Playlist folders music) = do
         , searchFw     = True
         , histSize     = optHistSize opts
         , miniFocused  = False
-        , exiting      = False
         , status       = Stopped
         , minibuffer   = Fast mempty defaultSty
         , uptime       = mempty
@@ -178,8 +177,6 @@ mpgLoop = runForever do
             writeIORef mpgProcess Nothing
             void $ takeMVar mpg
 
-            stop <- getsHS exiting
-            when stop exitSuccess
             threadDelay 1_000_000  -- let threads spit errors
             warnA $ "Restarting " ++ mppath ++ " ..."
 
@@ -244,7 +241,6 @@ mpgInput = runForever $ do
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
     UI.end
-    silentlyModifyHS $ \st -> st { exiting = True }
     discardErrors writeState
     mph <- readIORef mpgProcess
     whenJust mph \ph -> do

--- a/Core.hs
+++ b/Core.hs
@@ -35,7 +35,6 @@ import Data.Sequence qualified as Seq
 
 import Data.Array               ((!), Array)
 import Data.Proxy
-import Data.Time
 import Data.Tuple               (swap)
 import Control.Monad.Except
 import Control.Monad.State.Strict
@@ -150,8 +149,7 @@ mpgLoop = runForever do
     case empg of
 
         Left err -> do
-            now <- timeString
-            warnA $ err ++ " (" ++ now ++ ")"
+            warnA err
             -- Hackily count failed initial spawn, for Ready message
             silentlyModifyHS \st -> st { spawns = spawns st `max` 1 }
             threadDelay 20_000_000  -- longer wait after these errors
@@ -179,10 +177,6 @@ mpgLoop = runForever do
 
     -- Slow spawn loops in case of trouble.
     threadDelay 4_000_000
-
--- | Timestamp for spawn errors
-timeString :: IO String
-timeString = take 19 . show <$> (utcToLocalZonedTime =<< getCurrentTime)
 
 ------------------------------------------------------------------------
 

--- a/Core.hs
+++ b/Core.hs
@@ -64,11 +64,7 @@ data Options = Options
 start :: Options -> Playlist -> IO ()
 start opts (Playlist folders music) = do
 
-    config <- catch @SomeException UI.start \err -> do
-        -- An uncaught exception here would deadlock.
-        -- XXX more state model revisions should obviate need
-        hPutStrLn stderr $ "Curses failed to start: " ++ show err
-        exitImmediately $ ExitFailure 1
+    config <- UI.start
     bootTime <- getMonoTime
     let size = length music
     mode <- maybe readState pure (optPlayMode opts)
@@ -242,11 +238,12 @@ mpgInput = runForever $ do
 shutdown :: Maybe String -> IO ()
 shutdown ms = do
     UI.end
-    discardErrors writeState
     mph <- readIORef mpgProcess
     whenJust mph \ph -> do
-        discardErrors $ sendMpg Quit
-        void $ waitForProcess ph
+        discardErrors writeState
+        discardErrors do
+            sendMpg Quit
+            void $ waitForProcess ph
     exitImmediately =<< case ms of
         Just s -> hPutStrLn stderr s *> pure (ExitFailure 1)
         _      -> pure ExitSuccess

--- a/Decoder.hs
+++ b/Decoder.hs
@@ -5,7 +5,7 @@
 -- Wire protocol for mpg123
 
 module Decoder (
-    mpgParser, Cmd(..), cmdToBS,
+    mp3Tool, mpgParser, Cmd(..), cmdToBS,
     Msg(..), Id3(..), Status(..), Frame(..),
 ) where
 
@@ -13,6 +13,10 @@ import Base
 
 import Data.ByteString.Char8 qualified as P
 import Data.ByteString.UTF8 qualified as UTF8
+
+
+mp3Tool :: String
+mp3Tool = "mpg123"
 
 ------------------------------------------------------------------------
 -- Send commands to mpg123

--- a/Decoder.hs
+++ b/Decoder.hs
@@ -15,7 +15,7 @@ import Data.ByteString.Char8 qualified as P
 import Data.ByteString.UTF8 qualified as UTF8
 
 
-mp3Tool :: String
+mp3Tool :: IsString a => a
 mp3Tool = "mpg123"
 
 ------------------------------------------------------------------------

--- a/State.hs
+++ b/State.hs
@@ -99,7 +99,7 @@ sendMpg c = do
     else
         modifyHS_ \st -> st { minibuffer =
             case minibuffer st of -- don't overwrite if message already
-                Fast "" _ -> Fast "Decoder process not running" (warnings $ config st)
+                Fast "" _ -> Fast "mpg123 process not running" (warnings $ config st)
                 _         -> minibuffer st
         }
 

--- a/State.hs
+++ b/State.hs
@@ -45,7 +45,6 @@ data HState = HState
     , uptime          :: !ByteString
     , searchFw        :: !Bool                 -- active search direction
     , searchHist      :: ![ByteString]
-    , exiting         :: !Bool                 -- let mpg123 die?
     , playHist        :: !(Seq (TimeSpec, Int))
     , histSize        :: Int
     , config          :: !UIStyle

--- a/State.hs
+++ b/State.hs
@@ -9,7 +9,7 @@ module State where
 
 import Base
 
-import Decoder                  (Status, Frame, Id3, Cmd, cmdToBS)
+import Decoder                  (Status, Frame, Id3, Cmd, cmdToBS, mp3Tool)
 import Playlist                 (FileArray, DirArray)
 import Style                    (StringA(Fast), UIStyle, warnings)
 
@@ -99,7 +99,7 @@ sendMpg c = do
     else
         modifyHS_ \st -> st { minibuffer =
             case minibuffer st of -- don't overwrite if message already
-                Fast "" _ -> Fast "mpg123 process not running" (warnings $ config st)
+                Fast "" _ -> Fast (mp3Tool <> " process not running") (warnings $ config st)
                 _         -> minibuffer st
         }
 

--- a/State.hs
+++ b/State.hs
@@ -33,7 +33,6 @@ data HState = HState
     , cursor          :: !Int                  -- mp3 under the cursor
     , clock           :: !(Maybe Frame)        -- current clock value
     , randomGen       :: !StdGen               -- random seed
-    , mpgPid          :: !(Maybe ProcessHandle) -- pid of decoder
     , spawns          :: !Integer              -- count of decoder spawns
     , threads         :: ![ThreadId]           -- all our threads
     , id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
@@ -67,6 +66,11 @@ data Modal = HelpModal ![KeysHelp] | ExitModal | HistModal !HistDisplay
 hState :: MVar HState
 hState = unsafePerformIO newEmptyMVar
 {-# NOINLINE hState #-}
+
+-- | Decoder process handle
+mpgProcess :: IORef (Maybe ProcessHandle)
+mpgProcess = unsafePerformIO $ newIORef Nothing
+{-# NOINLINE mpgProcess #-}
 
 -- | The refresh thread waits on this
 modified :: MVar ()

--- a/State.hs
+++ b/State.hs
@@ -11,7 +11,7 @@ import Base
 
 import Decoder                  (Status, Frame, Id3, Cmd, cmdToBS)
 import Playlist                 (FileArray, DirArray)
-import Style                    (StringA, UIStyle)
+import Style                    (StringA(Fast), UIStyle, warnings)
 
 import Data.ByteString          (hPut)
 import System.Clock             (TimeSpec(..))
@@ -67,6 +67,7 @@ hState = unsafePerformIO newEmptyMVar
 {-# NOINLINE hState #-}
 
 -- | Decoder process handle
+-- If Just, handles should be somewhere.
 mpgProcess :: IORef (Maybe ProcessHandle)
 mpgProcess = unsafePerformIO $ newIORef Nothing
 {-# NOINLINE mpgProcess #-}
@@ -90,8 +91,17 @@ mpg = unsafePerformIO newEmptyMVar
 {-# NOINLINE mpg #-}
 
 sendMpg :: Cmd -> IO ()
-sendMpg c = withMVar mpg $ (. writeh) \h ->
-    hPut h (cmdToBS c) *> hPut h "\n" *> hFlush h
+sendMpg c = do
+    running <- isJust <$> readIORef mpgProcess
+    if running
+    then withMVar mpg $ (. writeh) \h ->
+        hPut h (cmdToBS c) *> hPut h "\n" *> hFlush h
+    else
+        modifyHS_ \st -> st { minibuffer =
+            case minibuffer st of -- don't overwrite if message already
+                Fast "" _ -> Fast "Decoder process not running" (warnings $ config st)
+                _         -> minibuffer st
+        }
 
 ------------------------------------------------------------------------
 -- state accessor functions

--- a/State.hs
+++ b/State.hs
@@ -78,34 +78,43 @@ setModified = void $ tryPutMVar modified ()
 ------------------------------------------------------------------------
 -- The decoder.
 
--- | Read/write handles.
-data Mpg = Mpg { errh :: !Handle, writeh :: !Handle }
+-- | Decoder read handle (mpg123 stderr).
+mpgRead :: MVar Handle
+mpgRead = unsafePerformIO newEmptyMVar
+{-# NOINLINE mpgRead #-}
 
-mpg :: MVar Mpg
-mpg = unsafePerformIO newEmptyMVar
-{-# NOINLINE mpg #-}
+data Mpg = Mpg { mpgPH :: !ProcessHandle, writeHM :: !(MVar Handle) }
 
--- | Decoder process handle
--- If Just, read/write handles should exist.
-mpgProcess :: IORef (Maybe ProcessHandle)
-mpgProcess = unsafePerformIO $ newIORef Nothing
-{-# NOINLINE mpgProcess #-}
+-- | Decoder process and write handles.
+mpgRef :: IORef (Maybe Mpg)
+mpgRef = unsafePerformIO $ newIORef Nothing
+{-# NOINLINE mpgRef #-}
 
 overseeMpg :: (Handle, Handle, Handle, ProcessHandle) -> IO ()
-overseeMpg (writeh, _, errh, ph) = do
-    putMVar mpg Mpg { errh, writeh }
-    writeIORef mpgProcess $ Just ph
-    void $ try @SomeException $ waitForProcess ph
-    writeIORef mpgProcess Nothing  -- reverse order
-    void $ takeMVar mpg
+overseeMpg (writeH, _, errH, mpgPH) = do
+    putMVar mpgRead errH
+    writeHM <- newMVar writeH
+    writeIORef mpgRef $ Just Mpg { mpgPH, writeHM }
+    void $ try @SomeException $ waitForProcess mpgPH
+    writeIORef mpgRef Nothing
+    void $ takeMVar mpgRead
 
+-- | Returns whether succeeded.
+sendMpg' :: Cmd -> IO Bool
+sendMpg' c = do
+    mpg <- readIORef mpgRef
+    case mpg of
+        Just Mpg { writeHM } -> do
+            h <- readMVar writeHM
+            fmap isRight $ try @SomeException $
+                hPut h (cmdToBS c) *> hPut h "\n" *> hFlush h
+        _ -> pure False
+
+-- | Runs above and posts warning on failure.
 sendMpg :: Cmd -> IO ()
 sendMpg c = do
-    running <- isJust <$> readIORef mpgProcess
-    if running
-    then withMVar mpg $ (. writeh) \h ->
-        hPut h (cmdToBS c) *> hPut h "\n" *> hFlush h
-    else
+    ok <- sendMpg' c
+    when (not ok) do
         modifyHS_ \st -> st { minibuffer =
             case minibuffer st of -- don't overwrite if message already
                 Fast "" _ -> Fast (mp3Tool <> " process not running") (warnings $ config st)

--- a/State.hs
+++ b/State.hs
@@ -66,12 +66,6 @@ hState :: MVar HState
 hState = unsafePerformIO newEmptyMVar
 {-# NOINLINE hState #-}
 
--- | Decoder process handle
--- If Just, handles should be somewhere.
-mpgProcess :: IORef (Maybe ProcessHandle)
-mpgProcess = unsafePerformIO $ newIORef Nothing
-{-# NOINLINE mpgProcess #-}
-
 -- | The refresh thread waits on this
 modified :: MVar ()
 modified = unsafePerformIO newEmptyMVar
@@ -84,11 +78,18 @@ setModified = void $ tryPutMVar modified ()
 ------------------------------------------------------------------------
 -- The decoder.
 
+-- | Read/write handles.
 data Mpg = Mpg { errh :: !Handle, writeh :: !Handle }
 
 mpg :: MVar Mpg
 mpg = unsafePerformIO newEmptyMVar
 {-# NOINLINE mpg #-}
+
+-- | Decoder process handle
+-- If Just, read/write handles should exist.
+mpgProcess :: IORef (Maybe ProcessHandle)
+mpgProcess = unsafePerformIO $ newIORef Nothing
+{-# NOINLINE mpgProcess #-}
 
 sendMpg :: Cmd -> IO ()
 sendMpg c = do
@@ -104,7 +105,7 @@ sendMpg c = do
         }
 
 ------------------------------------------------------------------------
--- state accessor functions
+-- State accessor functions.
 
 -- | Access a component of the state with a projection function
 getsHS :: (HState -> a) -> IO a

--- a/State.hs
+++ b/State.hs
@@ -16,7 +16,7 @@ import Style                    (StringA(Fast), UIStyle, warnings)
 import Data.ByteString          (hPut)
 import System.Clock             (TimeSpec(..))
 import System.IO                (hFlush)
-import System.Process           (ProcessHandle)
+import System.Process           (ProcessHandle, waitForProcess)
 import System.Random            (StdGen)
 
 
@@ -90,6 +90,14 @@ mpg = unsafePerformIO newEmptyMVar
 mpgProcess :: IORef (Maybe ProcessHandle)
 mpgProcess = unsafePerformIO $ newIORef Nothing
 {-# NOINLINE mpgProcess #-}
+
+overseeMpg :: (Handle, Handle, Handle, ProcessHandle) -> IO ()
+overseeMpg (writeh, _, errh, ph) = do
+    putMVar mpg Mpg { errh, writeh }
+    writeIORef mpgProcess $ Just ph
+    void $ try @SomeException $ waitForProcess ph
+    writeIORef mpgProcess Nothing  -- reverse order
+    void $ takeMVar mpg
 
 sendMpg :: Cmd -> IO ()
 sendMpg c = do

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -78,7 +78,6 @@ library
     process,
     random,
     regex-posix,
-    time,
     unix >=2.8,
     utf8-string,
 

--- a/hmp3-ng.cabal
+++ b/hmp3-ng.cabal
@@ -78,6 +78,7 @@ library
     process,
     random,
     regex-posix,
+    time,
     unix >=2.8,
     utf8-string,
 


### PR DESCRIPTION
Deadlocks in practice do not occur in normal operation of the app, but it'd be preferable to have a state model where they won't occur at all.  This tries to go some way towards accomplishing this, and also closes #119.

Past problem areas:

*  If mpg123 fails to run, the key loop can block forever waiting for a handle to send a message to.  The app is frozen and can't be quit from.
*  If `UI.start` failed, there was an issue where `shutdown` would block since there would never be an `hState`.  This was flagged by Claude Code, and I worked around it by surrounding `UI.start` with a bespoke `catch`.  But this was a band-aid.

The main idea is to remove `mpgPid` from `HState` and make it a top-level IORef (not an MVar, that's neither needed nor desirable).  In addition, I dropped the `exiting` field from `HState`, since it is only checked before a ~5 second delay before a respawn is attempted, and only set right before a process exit, so I cannot see how it would help, and it complicates things.

As a final needed adjustment, I only do a `writeState` when there is an mpg process.  This is a pragmatic approach as there almost always is one, and saving the state isn't a vital function.  Another option is to only save on non-error exit.  I'm not currently planning to think about this much, because I'm considering dropping state saving now that there is a CLI option for the mode.

Tested:

*  I modified `UI.start` to deliberately crash.  The process exited with no deadlock.
*  I set `mp3Tool` to a nonsense name.  The app warned but still opened.  I can browse and search songs, and trying to play throws a warning but doesn't deadlock.  I can quit the app.
*  I set the mpg123 executable to have a nonsense shebang `#!/path/to/nowhere`.  This causes `runInteractiveProcess` to fail.  Just like above, there is no locking.

It periodically retries in the latter two cases.  If I create or fix a link to the executable, I get a Ready message and can play music again.