### PR TITLE
Reduce DrawData, refactor, and extract more to Elements.

### DIFF
--- a/Decoder.hs
+++ b/Decoder.hs
@@ -10,7 +10,7 @@ module Decoder (
 ) where
 
 import Base
-import Text (trim, readIntM, guessEncoding)
+import Text (trim, readIntM, showInt, guessEncoding)
 
 import Data.ByteString.Char8 qualified as P
 
@@ -25,7 +25,7 @@ data Cmd = Load ByteString | Jump Int | Pause | Quit
 
 cmdToBS :: Cmd -> ByteString
 cmdToBS (Load f) = "L " <> f
-cmdToBS (Jump i) = "J " <> P.pack (show i) -- can be relative with +/-; not used here
+cmdToBS (Jump i) = "J " <> showInt i -- can be relative with +/-; not used here
 cmdToBS Pause    = "P"  -- (un)pauses
 cmdToBS Quit     = "Q"
 
@@ -101,8 +101,7 @@ doS s = do
     guard $ length fs >= 11
     hz <- readIntM $ fs !! 2
     pure $ S $ mconcat [
-        "mpeg ", fs !! 0, " ", fs !! 10, "kb/s ",
-            P.pack $ show $ hz `div` 1000, "kHz"]
+        "mpeg ", fs !! 0, " ", fs !! 10, "kb/s ", showInt $ hz `div` 1000, "kHz"]
 
 -- Track info if ID fields are in the file, otherwise file name.
 doI :: ByteString -> Maybe Msg

--- a/Elements.hs
+++ b/Elements.hs
@@ -5,8 +5,10 @@
 module Elements where
 
 import Base
+import Decoder (Frame(..))
 import Keyboard (charToKey, historyKeys)
 import State
+import Style (Style(..), StringA(..), defaultSty)
 import Text
 import Paths_hmp3_ng (version)
 
@@ -51,6 +53,36 @@ showDuration showSecs tm
     (d, h)  = hs `quotRem` 24
     ss      =
         if showSecs then (<> printf (if ms > 0 then "%02ds" else "%ds") s) else id
+
+-- | The time used and time left
+pTimes :: Int -> Maybe Frame -> ByteString
+pTimes w clock
+    | w - 4 < P.length elapsed = ""
+    | True                     =
+        mconcat $ ["  ", elapsed] ++ [gap <> "-" <> left | distance > 0]
+  where
+    elapsed  = showClock (maybe 0 (.currentTime) clock)
+    left     = maybe "?:??.?" (showClock . (.timeLeft)) clock
+    gap      = spaces distance
+    distance = w - 5 - P.length elapsed - P.length left
+
+-- | A progress bar
+progressBar :: Style -> Int -> Maybe Frame -> StringA
+progressBar sty sizeW = \case
+    Nothing         -> FancyS [pad, (spaces width, bgs)]
+    Just Frame {..} -> FancyS
+        [pad, (spaces distance, fgs), (spaces (width - distance), bgs)]
+      where
+        total    = curr + toRational timeLeft - ε
+        distance = ceiling (curr * fromIntegral (width - 1) / total)
+        curr     = toRational currentTime
+        ε        = toRational (succ 0 `asTypeOf` currentTime) / 2
+  where
+    pad         = ("  ", defaultSty)
+    width       = sizeW - 4
+    Style fg bg = sty
+    bgs         = Style bg bg
+    fgs         = Style fg fg
 
 
 -- Modals

--- a/Elements.hs
+++ b/Elements.hs
@@ -76,7 +76,7 @@ progressBar sty sizeW = \case
         total    = curr + toRational timeLeft - ε
         distance = ceiling (curr * fromIntegral (width - 1) / total)
         curr     = toRational currentTime
-        ε        = toRational (succ 0 `asTypeOf` currentTime) / 2
+        ε        = toRational (toEnum 1 `asTypeOf` currentTime) / 2
   where
     pad         = ("  ", defaultSty)
     width       = sizeW - 4

--- a/Text.hs
+++ b/Text.hs
@@ -7,7 +7,7 @@
 module Text (
     u, matches,
     trim, spaces, guessEncoding, dropLastUTF8,
-    readIntM,
+    readIntM, showInt,
     displayWidth, toMaxWidth, toWidth
 ) where
 
@@ -39,6 +39,9 @@ matches s = maybe (const False) match $
 
 readIntM :: ByteString -> Maybe Int
 readIntM = fmap fst . P.readInt
+
+showInt :: Int -> ByteString
+showInt = P.pack . show
 
 -- | If seeming ISO-8859-1, convert to UTF-8.
 guessEncoding :: ByteString -> ByteString

--- a/UI.hs
+++ b/UI.hs
@@ -145,13 +145,11 @@ refreshClock = runDraw $ redrawJustClock <> Draw Curses.refresh
 ------------------------------------------------------------------------
 
 -- (prefix some with underscore to avoid unused warnings)
-data Pos  = Pos  { posY, _posX :: !Int }
 data Size = Size { _sizeH, sizeW :: !Int }
 
 -- | Renderable widgets are functions @DrawData -> ...@.
 data DrawData = DD {
     drawSize  :: Size,
-    drawPos   :: Pos,
     drawState :: HState
     }
 
@@ -282,8 +280,8 @@ playTitle dd =
     hl      = titlebar . uiStyle $ drawState dd
 
 -- | The scrolling playlist (title + visible tracks + minibuffer).
-playList :: DrawData -> [StringA]
-playList dd@DD{ drawSize=Size y x, drawPos=Pos{posY=o}, drawState=st } =
+playList :: Int -> DrawData -> [StringA]
+playList height dd@DD{ drawSize=Size _ x, drawState=st } =
     playTitle dd
     : list
     ++ replicate (height - length list - 2) (Fast P.empty defaultSty)
@@ -292,7 +290,6 @@ playList dd@DD{ drawSize=Size y x, drawPos=Pos{posY=o}, drawState=st } =
     songs  = music st
     this   = current st
     curr   = cursor  st
-    height = y - o
 
     -- number of screens down, and then offset
     buflen = height - 2
@@ -350,7 +347,7 @@ redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
     st     <- getsHS id
     (h, w) <- screenSize
-    let dd = DD (Size h w) undefined st
+    let dd = DD (Size h w) st
     Curses.wMove Curses.stdScr 1 0
     drawLine $ progressBar dd
     Curses.wMove Curses.stdScr 2 0
@@ -386,8 +383,8 @@ redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
     st <- getsHS id    -- another refresh could be triggered?
     (h, w) <- screenSize
     let sz     = Size h w
-        screen = playScreen (DD sz (Pos 0 0) st)
-        a      = screen ++ playList (DD sz (Pos (length screen) 0) st)
+        screen = playScreen (DD sz st)
+        a      = screen ++ playList (h - length screen) (DD sz st)
 
     setXterm st
 

--- a/UI.hs
+++ b/UI.hs
@@ -5,10 +5,7 @@
 -- Derived from: riot/UI.hs Copyright (c) Tuomo Valkonen 2004.
 -- Released under the same license.
 
---
 -- | This module defines a user interface implemented using ncurses. 
---
---
 
 module UI (
     runDraw,
@@ -26,7 +23,7 @@ import Style
 import Playlist                 (File(fdir, fbase), Dir(dname))
 import State
 import Decoder
-import Text                     (u, displayWidth, toMaxWidth, toWidth, spaces)
+import Text                     (u, displayWidth, toMaxWidth, toWidth, spaces, showInt)
 import UI.HSCurses.Curses qualified as Curses
 import Keyboard                 (unkey)
 
@@ -144,10 +141,7 @@ refreshClock = runDraw $ redrawJustClock <> Draw Curses.refresh
 
 ------------------------------------------------------------------------
 
-data DrawData = DD {
-    drawWidth :: Int,
-    drawState :: HState
-    }
+data DrawData = DD { drawWidth :: Int, drawState :: HState }
 
 ------------------------------------------------------------------------
 
@@ -156,7 +150,7 @@ pPlaying :: DrawData -> StringA
 pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line <> "  " where
     x = dd.drawWidth
     a = pId3 dd
-    b = pInfo dd
+    b = fromMaybe "" dd.drawState.info  -- mp3 info
     line | gap >= 0 = a : spaces gap : right
          | True     = toMaxWidth lim a : right
         where lim = x - 5 - (if showId3 then P.length b else -1)
@@ -166,13 +160,7 @@ pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line <> "  " where
 
 -- | Id3 info
 pId3 :: DrawData -> ByteString
-pId3 DD{drawState=st} = case id3 st of
-    Just i  -> id3str i
-    Nothing -> fbase $ music st ! current st
-
--- | mp3 information
-pInfo :: DrawData -> ByteString
-pInfo DD{drawState=st} = fromMaybe "" $ info st
+pId3 DD{drawState=st} = maybe (st.music ! st.current).fbase (.id3str) st.id3
 
 ------------------------------------------------------------------------
 
@@ -204,69 +192,61 @@ progressBar DD {drawWidth=sizeW, drawState=st} = case st.clock of
   where
     pad         = ("  ", defaultSty)
     width       = sizeW - 4
-    Style fg bg = progress st.uiStyle
+    Style fg bg = st.uiStyle.progress
     bgs         = Style bg bg
     fgs         = Style fg fg
 
 ------------------------------------------------------------------------
 
--- | Uptime
-pTime :: DrawData -> ByteString
-pTime = uptime . drawState
-
 -- | Play state
 pState :: DrawData -> String
-pState dd = case status (drawState dd) of
+pState dd = case dd.drawState.status of
     Stopped -> "◼"
     Paused  -> "⏸"
     Playing -> "▶"
 
 -- | Play mode
 pMode :: DrawData -> String
-pMode dd = take 4 $ map toLower $ show $ mode $ drawState dd
+pMode dd = take 4 $ map toLower $ show dd.drawState.mode
 
 ------------------------------------------------------------------------
 
 -- | "x/n dirs y/m files" cursor position read-out.
 playInfo :: DrawData -> ByteString
-playInfo dd = mconcat
+playInfo DD{drawState=st} = mconcat
     [ spaces (P.length numd - P.length curd)
     , curd, "/", numd, " dirs"
     , spaces (1 + P.length numf - P.length curf)
     , curf, "/", numf, " files"
     ]
   where
-    st   = drawState dd
-    tobs = P.pack . show
-    curf  = tobs $ 1 + st.cursor
-    numf  = tobs $ st.size
-    mydir = fdir $ st.music ! st.cursor
-    curd  = tobs $ 1 + mydir
-    numd  = tobs $ length $ st.folders
+    curf  = showInt $ st.cursor + 1
+    numf  = showInt $ st.size
+    curd  = showInt $ (st.music ! st.cursor).fdir + 1
+    numd  = showInt $ length $ st.folders
 
 -- | The top title bar: cursor position + play indicator + uptime + version.
 playTitle :: DrawData -> StringA
-playTitle dd =
+playTitle dd@DD{drawWidth=w, drawState=st} =
     flip Fast hl $ mconcat if gap >= 2
-        then [" ", inf, spaces gapl, u indic, spaces gapr, time, " ", ver, " "]
-        else let gap' = x - indicl; gapl' = gap' `div` 2
+        then [" ", inf, spaces gapl, u indic, spaces gapr, uptime, " ", ver, " "]
+        else let gap' = w - indicl; gapl' = gap' `div` 2
              in if gap' >= 2
                 then [spaces gapl', u indic, spaces $ gap' - gapl']
-                else [" ", u $ take (x-2) indic, " "]
+                else [" ", u $ take (w-2) indic, " "]
   where
     inf     = playInfo dd
-    time    = pTime dd
+    uptime  = st.uptime
     indic   = pState dd ++ ' ' : pMode dd
     ver     = El.pVersion
-    x       = dd.drawWidth
     lsize   = 1 + P.length inf
-    rsize   = 2 + P.length time + P.length ver
-    side    = (x - indicl) `div` 2
-    gap     = x - indicl - lsize - rsize
+    rsize   = 2 + P.length uptime + P.length ver
+    side    = (w - indicl) `div` 2
+    gap     = w - indicl - lsize - rsize
     gapl    = 1 `max` ((side - lsize) `min` (gap - 1))
     gapr    = gap - gapl
     indicl  = 6 -- length indic
-    hl      = titlebar . uiStyle $ drawState dd
+    hl      = st.uiStyle.titlebar
 
 -- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]
@@ -294,7 +274,7 @@ playList buflen DD{ drawWidth=w, drawState=st } =
     indent = (round $ (0.334 :: Float) * fromIntegral w) :: Int
 
     (sty1, sty2, sty3) = (selected cs, cursors cs, combined cs)
-        where cs = uiStyle st
+        where cs = st.uiStyle
 
     color :: ((Maybe Int, ByteString), Int)
                 -> (Maybe Int, (Style, [ByteString]))
@@ -322,7 +302,7 @@ playList buflen DD{ drawWidth=w, drawState=st } =
 redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
     st     <- getsHS id
-    (h, w) <- screenSize
+    (_, w) <- screenSize
     let dd = DD w st
     Curses.wMove Curses.stdScr 1 0
     drawLine $ progressBar dd
@@ -337,10 +317,9 @@ renderModal st (h, w) mkr = do
         hoffset = max 0 $ (w - mw) `div` 2
         vislines = (h - 5) `min` length modal'
         voffset = ((h - vislines) `div` 2) `max` 4
-        sty = modals $ uiStyle st
     Curses.wMove Curses.stdScr voffset hoffset
     for_ (take vislines modal') \t -> do
-        drawLine $ Fast (toWidth mw t) sty
+        drawLine $ Fast (toWidth mw t) st.uiStyle.modals
         (y', _) <- Curses.getYX Curses.stdScr
         Curses.wMove Curses.stdScr (y'+1) hoffset
 
@@ -355,7 +334,7 @@ renderModals st sz =
 ------------------------------------------------------------------------
 -- | Draw the screen
 redraw :: Draw
-redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
+redraw = Draw do
     st <- getsHS id
     sz@(h, w) <- screenSize
     let dd  = DD w st
@@ -385,12 +364,12 @@ drawSegment bs sty = withStyle sty $ void $
     P.unsafeUseAsCStringLen bs \(cstr, len) ->
         waddnstr Curses.stdScr cstr (fromIntegral len)
 
-
 ------------------------------------------------------------------------
 
 -- | Fill to end of line spaces
+-- (Curses throws error if already at end.)
 fillLine :: IO ()
-fillLine = discardErrors Curses.clrToEol -- harmless?
+fillLine = discardErrors Curses.clrToEol
 
 -- | Take a slice of an array efficiently
 slice :: Int -> Int -> Array Int e -> [e]

--- a/UI.hs
+++ b/UI.hs
@@ -146,7 +146,7 @@ data DrawData = DD { drawWidth :: Int, drawState :: HState }
 
 -- | Info about the current track
 pPlaying :: DrawData -> StringA
-pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line <> "  " where
+pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line where
     x = dd.drawWidth
     a = pId3 dd
     b = fromMaybe "" dd.drawState.info  -- mp3 info
@@ -201,27 +201,23 @@ playInfo DD{drawState=st} = mconcat
 -- | The top title bar: cursor position + play indicator + uptime + version.
 playTitle :: DrawData -> StringA
 playTitle dd@DD{drawWidth=w, drawState=st} =
-    flip Fast hl $ mconcat if gap >= 2
-        then [" ", inf, spaces gapl, u indic, spaces gapr, st.uptime, " ", ver, " "]
-        else let gap' = w - indicl; gapl' = gap' `div` 2
-             in if gap' >= 2
-                then [spaces gapl', u indic, spaces $ gap' - gapl']
-                else [" ", u $ take (w-2) indic, " "]
+    flip Fast st.uiStyle.titlebar $ mconcat if gap >= 2
+        then [left, spaces gapl, u centerS, spaces (gap - gapl), right]
+        else if sides >= 2
+            then [spaces side, u centerS, spaces $ sides - side]
+            else [" ", u $ take (w-2) centerS, " "]
   where
-    inf     = playInfo dd
-    indic   = pState dd ++ ' ' : pMode dd
-    ver     = El.pVersion
-    lsize   = 1 + P.length inf
-    rsize   = 2 + P.length st.uptime + P.length ver
-    side    = (w - indicl) `div` 2
-    gap     = w - indicl - lsize - rsize
-    gapl    = 1 `max` ((side - lsize) `min` (gap - 1))
-    gapr    = gap - gapl
-    indicl  = 6 -- length indic
-    hl      = st.uiStyle.titlebar
+    left    = " " <> playInfo dd
+    centerS = pState dd ++ ' ' : pMode dd  -- always 6 chars
+    right   = st.uptime <> " " <> El.pVersion <> " "
+    sides   = w - 6
+    side    = sides `div` 2
+    gap     = sides - P.length left - P.length right
+    gapl    = 1 `max` ((side - P.length left) `min` (gap - 1))
 
 -- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]
+playList buflen _ | buflen <= 0 = []  -- extra defense besides laziness
 playList buflen DD{ drawWidth=w, drawState=st } =
     list ++ replicate (buflen - length list) (Fast "" defaultSty)
 
@@ -243,7 +239,7 @@ playList buflen DD{ drawWidth=w, drawState=st } =
 
     list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
-    indent = (round $ (0.334 :: Float) * fromIntegral w) :: Int
+    indent = round $ (0.334 :: Float) * fromIntegral w :: Int
 
     (sty1, sty2, sty3) = (cs.selected, cs.cursors, cs.combined)
         where cs = st.uiStyle
@@ -272,7 +268,7 @@ playList buflen DD{ drawWidth=w, drawState=st } =
 ------------------------------------------------------------------------
 -- | Write out only the clock lines.
 redrawJustClock :: Draw
-redrawJustClock = Draw do
+redrawJustClock = Draw $ discardErrors do
     st <- getsHS id
     (h, w) <- screenSize
     drawFullLines (h-1) 1 $ clockLines $ DD w st
@@ -301,8 +297,9 @@ renderModals st sz =
 
 ------------------------------------------------------------------------
 -- | Draw the screen
+-- Errors can maybe be thrown if screen gets resized mid-render.
 redraw :: Draw
-redraw = Draw do
+redraw = Draw $ discardErrors do
     st <- getsHS id
     sz@(h, w) <- screenSize
     setXterm st
@@ -346,7 +343,7 @@ fillLine = discardErrors Curses.clrToEol
 slice :: Int -> Int -> Array Int e -> [e]
 slice i j arr = 
     let (a, b) = bounds arr
-    in [unsafeAt arr n | n <- [max a i .. min b j] ]
+    in [unsafeAt arr n | n <- [max a i .. min b j]]
 {-# INLINE slice #-}
 
 ------------------------------------------------------------------------

--- a/UI.hs
+++ b/UI.hs
@@ -117,9 +117,8 @@ getKey = do
 
 -- | Resize the window
 -- From "Writing Programs with NCURSES", by Eric S. Raymond and Zeyd M. Ben-Halim
---
 resizeui :: Draw
-resizeui = Draw $ void $ do
+resizeui = Draw do
     Curses.endWin
     Curses.resetParams
     do
@@ -131,7 +130,7 @@ resizeui = Draw $ void $ do
         -- Curses.meta stdScr True -- not in module
         -- not sure about intrFlush, raw - set in hscurses
     Curses.refresh
-    Curses.scrSize
+    void Curses.scrSize
 
 refresh :: IO ()
 refresh = runDraw $ redraw <> Draw Curses.refresh
@@ -203,18 +202,17 @@ playInfo DD{drawState=st} = mconcat
 playTitle :: DrawData -> StringA
 playTitle dd@DD{drawWidth=w, drawState=st} =
     flip Fast hl $ mconcat if gap >= 2
-        then [" ", inf, spaces gapl, u indic, spaces gapr, uptime, " ", ver, " "]
+        then [" ", inf, spaces gapl, u indic, spaces gapr, st.uptime, " ", ver, " "]
         else let gap' = w - indicl; gapl' = gap' `div` 2
              in if gap' >= 2
                 then [spaces gapl', u indic, spaces $ gap' - gapl']
                 else [" ", u $ take (w-2) indic, " "]
   where
     inf     = playInfo dd
-    uptime  = st.uptime
     indic   = pState dd ++ ' ' : pMode dd
     ver     = El.pVersion
     lsize   = 1 + P.length inf
-    rsize   = 2 + P.length uptime + P.length ver
+    rsize   = 2 + P.length st.uptime + P.length ver
     side    = (w - indicl) `div` 2
     gap     = w - indicl - lsize - rsize
     gapl    = 1 `max` ((side - lsize) `min` (gap - 1))
@@ -241,13 +239,13 @@ playList buflen DD{ drawWidth=w, drawState=st } =
         loop _ []     = []
         loop n (v:vs) =
             let r = if v.fdir > n then Just v.fdir else Nothing
-            in (r, toWidth (w - indent - 1) v.fbase) : loop v.fdir vs
+            in (r, toMaxWidth (w - indent - 1) v.fbase) : loop v.fdir vs
 
     list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
     indent = (round $ (0.334 :: Float) * fromIntegral w) :: Int
 
-    (sty1, sty2, sty3) = (selected cs, cursors cs, combined cs)
+    (sty1, sty2, sty3) = (cs.selected, cs.cursors, cs.combined)
         where cs = st.uiStyle
 
     color :: ((Maybe Int, ByteString), Int)
@@ -269,10 +267,10 @@ playList buflen DD{ drawWidth=w, drawState=st } =
         : map (, sty) v
       where
         sty' = if sty == sty2 || sty == sty3 then sty2 else sty1
-        d = toMaxWidth (indent - 1) $ takeFileName (folders st ! i).dname
+        d = toMaxWidth (indent - 1) $ takeFileName (st.folders ! i).dname
 
 ------------------------------------------------------------------------
--- | Now write out just the clock line
+-- | Write out only the clock lines.
 redrawJustClock :: Draw
 redrawJustClock = Draw do
     st <- getsHS id
@@ -307,10 +305,9 @@ redraw :: Draw
 redraw = Draw do
     st <- getsHS id
     sz@(h, w) <- screenSize
-    let dd  = DD w st
-        tot = pPlaying dd : clockLines dd ++ playTitle dd : playList (h-5) dd
     setXterm st
-    drawFullLines (h-1) 0 tot
+    drawFullLines (h-1) 0 $ let dd = DD w st in
+        pPlaying dd : clockLines dd ++ playTitle dd : playList (h-5) dd
     renderModals st sz
     -- minibuffer
     Curses.wMove Curses.stdScr (h-1) 0
@@ -319,7 +316,7 @@ redraw = Draw do
         drawLine $ Fast " " st.uiStyle.blockcursor
     fillLine
 
--- | Render whole lines without going below height.
+-- | Render whole lines without going below limit.
 drawFullLines :: Int -> Int -> [StringA] -> IO ()
 drawFullLines limit y ls =
     for_ (zip [y .. limit-1] ls) \ (y', t) -> do
@@ -367,13 +364,11 @@ setXtermTitle strs = do
 
 -- set xterm title.  Don't need to do this on each refresh...
 setXterm :: HState -> IO ()
-setXterm s = setXtermTitle $ case status s of
-    Playing -> case id3 s of
-        Nothing -> [fbase $ music s ! current s]
-        Just ti -> id3artist ti :
-                   if P.null (id3title ti)
-                        then []
-                        else [": ", id3title ti]
+setXterm st = setXtermTitle case st.status of
+    Playing -> case st.id3 of
+        Just id3 -> id3.id3artist :
+                       if P.null id3.id3title then [] else [": ", id3.id3title]
+        _        -> [(st.music ! st.current).fbase]
     Paused  -> ["paused"]
     Stopped -> ["stopped"]
 

--- a/UI.hs
+++ b/UI.hs
@@ -155,15 +155,9 @@ data DrawData = DD {
 
 ------------------------------------------------------------------------
 
--- | The three lines of the play info widget.
-playScreen :: DrawData -> [StringA]
-playScreen dd = [pPlaying dd, progressBar dd, pTimes dd]
-
-------------------------------------------------------------------------
-
 -- | Info about the current track
 pPlaying :: DrawData -> StringA
-pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line where
+pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line <> "  " where
     x = sizeW $ drawSize dd
     a = pId3 dd
     b = pInfo dd
@@ -203,17 +197,16 @@ pTimes DD { drawState=st, drawSize=Size{sizeW=w} } =
 -- | A progress bar
 progressBar :: DrawData -> StringA
 progressBar DD{drawSize=Size{sizeW}, drawState=st} = case st.clock of
-    Nothing         -> FancyS [("  ", defaultSty), (spaces width, bgs)]
+    Nothing         -> FancyS [pad, (spaces width, bgs)]
     Just Frame {..} -> FancyS
-        [ ("  ", defaultSty)
-        , (spaces distance, fgs)
-        , (spaces (width - distance), bgs) ]
+        [pad, (spaces distance, fgs), (spaces (width - distance), bgs)]
       where
         total    = curr + toRational timeLeft - ε
         distance = ceiling (curr * fromIntegral (width - 1) / total)
         curr     = toRational currentTime
         ε        = toRational (succ 0 `asTypeOf` currentTime) / 2
   where
+    pad         = ("  ", defaultSty)
     width       = sizeW - 4
     Style fg bg = progress st.uiStyle
     bgs         = Style bg bg
@@ -279,39 +272,26 @@ playTitle dd =
     indicl  = 6 -- length indic
     hl      = titlebar . uiStyle $ drawState dd
 
--- | The scrolling playlist (title + visible tracks + minibuffer).
+-- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]
-playList height dd@DD{ drawSize=Size _ x, drawState=st } =
-    playTitle dd
-    : list
-    ++ replicate (height - length list - 2) (Fast P.empty defaultSty)
-    ++ [minibuffer st]
+playList buflen DD{ drawSize=Size _ x, drawState=st } =
+    list ++ replicate (buflen - length list) (Fast "" defaultSty)
+
   where
-    songs  = music st
-    this   = current st
-    curr   = cursor  st
-
     -- number of screens down, and then offset
-    buflen = height - 2
-    (screens, select) = quotRem curr buflen -- keep cursor in screen
-
-    playing = let top = screens * buflen
-                  bot = (screens + 1) * buflen
-              in if this >= top && this < bot
-                    then this - top -- playing song is visible
-                    else (-1)
+    (screens, select) = st.cursor `quotRem` buflen -- keep cursor in screen
+    playing = st.current - screens * buflen -- invisible if out of bounds
 
     -- visible slice of the playlist
-    visible = slice off (off + buflen) songs
+    visible = slice off (off + buflen - 1) st.music
         where off = screens * buflen
 
     visible' :: [(Maybe Int, ByteString)]
     visible' = loop (-1) visible where
         loop _ []     = []
         loop n (v:vs) =
-            let r = if fdir v > n then Just (fdir v) else Nothing
-            in (r, toMaxWidth (x - indent - 1) $ fbase v)
-                    : loop (fdir v) vs
+            let r = if v.fdir > n then Just v.fdir else Nothing
+            in (r, toWidth (x - indent - 1) v.fbase) : loop v.fdir vs
 
     list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
@@ -339,7 +319,7 @@ playList height dd@DD{ drawSize=Size _ x, drawState=st } =
         : map (, sty) v
       where
         sty' = if sty == sty2 || sty == sty3 then sty2 else sty1
-        d = toMaxWidth (indent - 1) $ takeFileName $ dname $ folders st ! i
+        d = toMaxWidth (indent - 1) $ takeFileName (folders st ! i).dname
 
 ------------------------------------------------------------------------
 -- | Now write out just the clock line
@@ -371,7 +351,7 @@ renderModal st (Size h w) mkr = do
 -- | Choose modal to render based on state.
 renderModals :: HState -> Size -> IO ()
 renderModals st sz =
-    whenJust (modal st) $ renderModal st sz . \case
+    whenJust st.modal $ renderModal st sz . \case
         HelpModal h -> El.helpModal h
         HistModal h -> El.histModal h
         ExitModal   -> El.exitModal
@@ -380,31 +360,23 @@ renderModals st sz =
 -- | Draw the screen
 redraw :: Draw
 redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
-    st <- getsHS id    -- another refresh could be triggered?
+    st <- getsHS id
     (h, w) <- screenSize
-    let sz     = Size h w
-        screen = playScreen (DD sz st)
-        a      = screen ++ playList (h - length screen) (DD sz st)
-
+    let sz  = Size h w
+        dd  = DD sz st
+        tot = [pPlaying dd, progressBar dd, pTimes dd, playTitle dd]
+                ++ playList (h-5) dd
     setXterm st
-
-    gotoTop
-    for_ (take (h-1) (init a)) \t -> do
-        drawLine t
-        (y, x) <- Curses.getYX Curses.stdScr
-        fillLine
-        maybeLineDown t h y x
+    for_ (zip [0..h-2] tot) \ (y, t) -> do
+        Curses.wMove Curses.stdScr y 0
+        drawLine t *> fillLine
     renderModals st sz
-
     -- minibuffer
     Curses.wMove Curses.stdScr (h-1) 0
+    drawLine st.minibuffer
+    when st.miniFocused do -- a fake cursor
+        drawLine $ Fast " " st.uiStyle.blockcursor
     fillLine
-    Curses.wMove Curses.stdScr (h-1) 0
-    drawLine (last a)
-    when (miniFocused st) do -- a fake cursor
-        drawLine (Fast (spaces 1) (blockcursor . uiStyle $ st ))
-        -- XXX is this TODO from 2005 still relevant?
-        -- todo rendering bug here when deleting backwards in minibuffer
 
 ------------------------------------------------------------------------
 -- | Draw a coloured (or not) string to the screen
@@ -421,25 +393,9 @@ drawSegment bs sty = withStyle sty $ void $
 
 ------------------------------------------------------------------------
 
-maybeLineDown :: StringA -> Int -> Int -> Int -> IO ()
-maybeLineDown (Fast s _) h y _ | s == P.empty = lineDown h y
-maybeLineDown _ h y x
-    | x == 0    = pure ()     -- already moved down
-    | otherwise = lineDown h y
-
-------------------------------------------------------------------------
-
-lineDown :: Int -> Int -> IO ()
-lineDown h y = Curses.wMove Curses.stdScr (min h (y+1)) 0
-
 -- | Fill to end of line spaces
 fillLine :: IO ()
 fillLine = discardErrors Curses.clrToEol -- harmless?
-
--- | move cursor to origin of stdScr.
-gotoTop :: IO ()
-gotoTop = Curses.wMove Curses.stdScr 0 0
-{-# INLINE gotoTop #-}
 
 -- | Take a slice of an array efficiently
 slice :: Int -> Int -> Array Int e -> [e]

--- a/UI.hs
+++ b/UI.hs
@@ -164,37 +164,11 @@ pId3 DD{drawState=st} = maybe (st.music ! st.current).fbase (.id3str) st.id3
 
 ------------------------------------------------------------------------
 
--- | The time used and time left
-pTimes :: DrawData -> StringA
-pTimes DD { drawState=st, drawWidth=w } =
-    flip Fast defaultSty $ if w - 4 < P.length elapsed
-        then ""
-        else mconcat $ ["  ", elapsed] ++ [gap <> "-" <> remaining | distance > 0]
-  where
-    elapsed   = showClock (maybe 0 (.currentTime) st.clock)
-    remaining = maybe "?:??.?" (showClock . (.timeLeft)) st.clock
-    gap       = spaces distance
-    distance  = w - 5 - P.length elapsed - P.length remaining
-
-------------------------------------------------------------------------
-
--- | A progress bar
-progressBar :: DrawData -> StringA
-progressBar DD {drawWidth=sizeW, drawState=st} = case st.clock of
-    Nothing         -> FancyS [pad, (spaces width, bgs)]
-    Just Frame {..} -> FancyS
-        [pad, (spaces distance, fgs), (spaces (width - distance), bgs)]
-      where
-        total    = curr + toRational timeLeft - ε
-        distance = ceiling (curr * fromIntegral (width - 1) / total)
-        curr     = toRational currentTime
-        ε        = toRational (succ 0 `asTypeOf` currentTime) / 2
-  where
-    pad         = ("  ", defaultSty)
-    width       = sizeW - 4
-    Style fg bg = st.uiStyle.progress
-    bgs         = Style bg bg
-    fgs         = Style fg fg
+-- | Two lines showing clock.
+clockLines :: DrawData -> [StringA]
+clockLines (DD w st) = [
+    El.progressBar st.uiStyle.progress w st.clock,
+    Fast (El.pTimes w st.clock) defaultSty ]
 
 ------------------------------------------------------------------------
 
@@ -300,14 +274,10 @@ playList buflen DD{ drawWidth=w, drawState=st } =
 ------------------------------------------------------------------------
 -- | Now write out just the clock line
 redrawJustClock :: Draw
-redrawJustClock = Draw $ discardErrors do
-    st     <- getsHS id
-    (_, w) <- screenSize
-    let dd = DD w st
-    Curses.wMove Curses.stdScr 1 0
-    drawLine $ progressBar dd
-    Curses.wMove Curses.stdScr 2 0
-    drawLine $ pTimes dd
+redrawJustClock = Draw do
+    st <- getsHS id
+    (h, w) <- screenSize
+    drawFullLines (h-1) 1 $ clockLines $ DD w st
 
 ------------------------------------------------------------------------
 -- | General modal renderer.
@@ -338,12 +308,9 @@ redraw = Draw do
     st <- getsHS id
     sz@(h, w) <- screenSize
     let dd  = DD w st
-        tot = [pPlaying dd, progressBar dd, pTimes dd, playTitle dd]
-                ++ playList (h-5) dd
+        tot = pPlaying dd : clockLines dd ++ playTitle dd : playList (h-5) dd
     setXterm st
-    for_ (zip [0..h-2] tot) \ (y, t) -> do
-        Curses.wMove Curses.stdScr y 0
-        drawLine t *> fillLine
+    drawFullLines (h-1) 0 tot
     renderModals st sz
     -- minibuffer
     Curses.wMove Curses.stdScr (h-1) 0
@@ -351,6 +318,13 @@ redraw = Draw do
     when st.miniFocused do -- a fake cursor
         drawLine $ Fast " " st.uiStyle.blockcursor
     fillLine
+
+-- | Render whole lines without going below height.
+drawFullLines :: Int -> Int -> [StringA] -> IO ()
+drawFullLines limit y ls =
+    for_ (zip [y .. limit-1] ls) \ (y', t) -> do
+        Curses.wMove Curses.stdScr y' 0
+        drawLine t *> fillLine
 
 ------------------------------------------------------------------------
 -- | Draw a coloured (or not) string to the screen

--- a/UI.hs
+++ b/UI.hs
@@ -152,8 +152,7 @@ data Size = Size { _sizeH, sizeW :: !Int }
 data DrawData = DD {
     drawSize  :: Size,
     drawPos   :: Pos,
-    drawState :: HState,
-    drawFrame :: Maybe Frame
+    drawState :: HState
     }
 
 ------------------------------------------------------------------------
@@ -191,13 +190,13 @@ pInfo DD{drawState=st} = fromMaybe "" $ info st
 
 -- | The time used and time left
 pTimes :: DrawData -> StringA
-pTimes DD { drawFrame, drawSize=Size{sizeW=w} } =
+pTimes DD { drawState=st, drawSize=Size{sizeW=w} } =
     flip Fast defaultSty $ if w - 4 < P.length elapsed
         then ""
         else mconcat $ ["  ", elapsed] ++ [gap <> "-" <> remaining | distance > 0]
   where
-    elapsed   = showClock (maybe 0 currentTime drawFrame)
-    remaining = maybe "?:??.?" (showClock . timeLeft) drawFrame
+    elapsed   = showClock (maybe 0 (.currentTime) st.clock)
+    remaining = maybe "?:??.?" (showClock . (.timeLeft)) st.clock
     gap       = spaces distance
     distance  = w - 5 - P.length elapsed - P.length remaining
 
@@ -205,7 +204,7 @@ pTimes DD { drawFrame, drawSize=Size{sizeW=w} } =
 
 -- | A progress bar
 progressBar :: DrawData -> StringA
-progressBar dd@DD{drawSize=Size{sizeW}, drawState=st} = case drawFrame dd of
+progressBar DD{drawSize=Size{sizeW}, drawState=st} = case st.clock of
     Nothing         -> FancyS [("  ", defaultSty), (spaces width, bgs)]
     Just Frame {..} -> FancyS
         [ ("  ", defaultSty)
@@ -218,7 +217,7 @@ progressBar dd@DD{drawSize=Size{sizeW}, drawState=st} = case drawFrame dd of
         ε        = toRational (succ 0 `asTypeOf` currentTime) / 2
   where
     width       = sizeW - 4
-    Style fg bg = progress (uiStyle st)
+    Style fg bg = progress st.uiStyle
     bgs         = Style bg bg
     fgs         = Style fg fg
 
@@ -351,7 +350,7 @@ redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
     st     <- getsHS id
     (h, w) <- screenSize
-    let dd = DD (Size h w) undefined st (clock st)
+    let dd = DD (Size h w) undefined st
     Curses.wMove Curses.stdScr 1 0
     drawLine $ progressBar dd
     Curses.wMove Curses.stdScr 2 0
@@ -387,8 +386,8 @@ redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
     st <- getsHS id    -- another refresh could be triggered?
     (h, w) <- screenSize
     let sz     = Size h w
-        screen = playScreen (DD sz (Pos 0 0) st (clock st))
-        a      = screen ++ playList (DD sz (Pos (length screen) 0) st (clock st))
+        screen = playScreen (DD sz (Pos 0 0) st)
+        a      = screen ++ playList (DD sz (Pos (length screen) 0) st)
 
     setXterm st
 

--- a/UI.hs
+++ b/UI.hs
@@ -144,12 +144,8 @@ refreshClock = runDraw $ redrawJustClock <> Draw Curses.refresh
 
 ------------------------------------------------------------------------
 
--- (prefix some with underscore to avoid unused warnings)
-data Size = Size { _sizeH, sizeW :: !Int }
-
--- | Renderable widgets are functions @DrawData -> ...@.
 data DrawData = DD {
-    drawSize  :: Size,
+    drawWidth :: Int,
     drawState :: HState
     }
 
@@ -158,7 +154,7 @@ data DrawData = DD {
 -- | Info about the current track
 pPlaying :: DrawData -> StringA
 pPlaying dd = flip Fast defaultSty $ "  " <> mconcat line <> "  " where
-    x = sizeW $ drawSize dd
+    x = dd.drawWidth
     a = pId3 dd
     b = pInfo dd
     line | gap >= 0 = a : spaces gap : right
@@ -182,7 +178,7 @@ pInfo DD{drawState=st} = fromMaybe "" $ info st
 
 -- | The time used and time left
 pTimes :: DrawData -> StringA
-pTimes DD { drawState=st, drawSize=Size{sizeW=w} } =
+pTimes DD { drawState=st, drawWidth=w } =
     flip Fast defaultSty $ if w - 4 < P.length elapsed
         then ""
         else mconcat $ ["  ", elapsed] ++ [gap <> "-" <> remaining | distance > 0]
@@ -196,7 +192,7 @@ pTimes DD { drawState=st, drawSize=Size{sizeW=w} } =
 
 -- | A progress bar
 progressBar :: DrawData -> StringA
-progressBar DD{drawSize=Size{sizeW}, drawState=st} = case st.clock of
+progressBar DD {drawWidth=sizeW, drawState=st} = case st.clock of
     Nothing         -> FancyS [pad, (spaces width, bgs)]
     Just Frame {..} -> FancyS
         [pad, (spaces distance, fgs), (spaces (width - distance), bgs)]
@@ -262,7 +258,7 @@ playTitle dd =
     time    = pTime dd
     indic   = pState dd ++ ' ' : pMode dd
     ver     = El.pVersion
-    x       = sizeW $ drawSize dd
+    x       = dd.drawWidth
     lsize   = 1 + P.length inf
     rsize   = 2 + P.length time + P.length ver
     side    = (x - indicl) `div` 2
@@ -274,7 +270,7 @@ playTitle dd =
 
 -- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]
-playList buflen DD{ drawSize=Size _ x, drawState=st } =
+playList buflen DD{ drawWidth=w, drawState=st } =
     list ++ replicate (buflen - length list) (Fast "" defaultSty)
 
   where
@@ -291,11 +287,11 @@ playList buflen DD{ drawSize=Size _ x, drawState=st } =
         loop _ []     = []
         loop n (v:vs) =
             let r = if v.fdir > n then Just v.fdir else Nothing
-            in (r, toWidth (x - indent - 1) v.fbase) : loop v.fdir vs
+            in (r, toWidth (w - indent - 1) v.fbase) : loop v.fdir vs
 
     list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
-    indent = (round $ (0.334 :: Float) * fromIntegral x) :: Int
+    indent = (round $ (0.334 :: Float) * fromIntegral w) :: Int
 
     (sty1, sty2, sty3) = (selected cs, cursors cs, combined cs)
         where cs = uiStyle st
@@ -308,7 +304,7 @@ playList buflen DD{ drawSize=Size _ x, drawState=st } =
         (_   , True) -> f sty1
         _            -> (defaultSty, [s])
       where
-        f sty = (sty, [s, spaces (x - indent - 1 - displayWidth s)])
+        f sty = (sty, [s, spaces (w - indent - 1 - displayWidth s)])
 
     drawIt :: (Maybe Int, (Style, [ByteString])) -> StringA
     drawIt (Nothing, (sty, v)) =
@@ -327,7 +323,7 @@ redrawJustClock :: Draw
 redrawJustClock = Draw $ discardErrors do
     st     <- getsHS id
     (h, w) <- screenSize
-    let dd = DD (Size h w) st
+    let dd = DD w st
     Curses.wMove Curses.stdScr 1 0
     drawLine $ progressBar dd
     Curses.wMove Curses.stdScr 2 0
@@ -335,8 +331,8 @@ redrawJustClock = Draw $ discardErrors do
 
 ------------------------------------------------------------------------
 -- | General modal renderer.
-renderModal :: HState -> Size -> ModalMaker -> IO ()
-renderModal st (Size h w) mkr = do
+renderModal :: HState -> (Int, Int) -> ModalMaker -> IO ()
+renderModal st (h, w) mkr = do
     let (mw, modal') = mkr w
         hoffset = max 0 $ (w - mw) `div` 2
         vislines = (h - 5) `min` length modal'
@@ -349,7 +345,7 @@ renderModal st (Size h w) mkr = do
         Curses.wMove Curses.stdScr (y'+1) hoffset
 
 -- | Choose modal to render based on state.
-renderModals :: HState -> Size -> IO ()
+renderModals :: HState -> (Int, Int) -> IO ()
 renderModals st sz =
     whenJust st.modal $ renderModal st sz . \case
         HelpModal h -> El.helpModal h
@@ -361,9 +357,8 @@ renderModals st sz =
 redraw :: Draw
 redraw = Draw $ discardErrors {- TODO what errors are discarded? -} do
     st <- getsHS id
-    (h, w) <- screenSize
-    let sz  = Size h w
-        dd  = DD sz st
+    sz@(h, w) <- screenSize
+    let dd  = DD w st
         tot = [pPlaying dd, progressBar dd, pTimes dd, playTitle dd]
                 ++ playList (h-5) dd
     setXterm st

--- a/test/ElementsSpec.hs
+++ b/test/ElementsSpec.hs
@@ -9,7 +9,7 @@ import Elements (showDuration)
 
 tests :: TestTree
 tests = testGroup "Elements"
-    [ testGroup "showDuration (secs=False)"
+    [ testGroup "showDuration (showSecs=False)"
         [ testCase "under a minute is 0m"
             $ showDuration False (t 30)    @?= "0m"
         , testCase "exactly one minute"
@@ -25,7 +25,7 @@ tests = testGroup "Elements"
         , testCase "day, hour, minute"
             $ showDuration False (t 90060) @?= "1d01h01m"
         ]
-    , testGroup "showDuration (secs=True)"
+    , testGroup "showDuration (showSecs=True)"
         [ testCase "thirty seconds"
             $ showDuration True (t 30)      @?= "30s"
         , testCase "one minute exactly appends 00s"


### PR DESCRIPTION
*  The formerly clunky DrawData is slimmed.  Possibly it can eventually be eliminated, but for now 8 functions still take it.
*  More pure, testable functions are moved to `Elements.hs`.
*  A bunch of `UI.hs` code is refactored and tidied and made (I hope) clearer and cleaner, especially `playList`, whose scope I reduced (though it's still a large function).
*  In the course of this, major progress is made on #143, though there are still bits to deal with to finish it.
*  More record dot usage, which is proving itself very ergonomic.  `NoFieldSelectors` is on the horizon.