### PR TITLE
Take threads out of state; poll before playing.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -71,13 +71,6 @@ start opts (Playlist folders music) = do
     let (current, randomGen) = if mode == Random || optRandom opts
         then randomR (0, length music - 1) gen else (0, gen)
 
-    threads <- traverse forkIO
-        [ mpgLoop
-        , mpgInput
-        , refreshLoop
-        , uptimeLoop
-        ]
-
     putMVar hState HState
         { music
         , folders
@@ -88,7 +81,6 @@ start opts (Playlist folders music) = do
         , randomGen
         , mode
         , uiStyle
-        , threads
         , spawns       = 0
         , clock        = Nothing
         , info         = Nothing
@@ -106,8 +98,27 @@ start opts (Playlist folders music) = do
 
     loadConfig  -- TODO this should return config rather than setting it
 
-    playCur
-    when (optPaused opts) pause -- TODO use LOADPAUSED?
+    traverse_ forkIO
+        [ mpgLoop
+        , mpgInput
+        , refreshLoop
+        , uptimeLoop
+        ]
+
+    -- Poll for a second for process to start, then play.
+    let go :: Int -> IO ()
+        go 0 = silentlyModifyHS \st -> st { spawns = 1 }
+        go n = do
+            ready <- isJust <$> readIORef mpgRef
+            if ready
+                then do
+                    playCur
+                    when (optPaused opts) pause -- TODO use LOADPAUSED?
+                else do
+                    threadDelay 20_000
+                    go (n-1)
+    go 50
+
 
 ------------------------------------------------------------------------
 

--- a/State.hs
+++ b/State.hs
@@ -35,7 +35,6 @@ data HState = HState
     , clock           :: !(Maybe Frame)        -- current clock value
     , randomGen       :: !StdGen               -- random seed
     , spawns          :: !Integer              -- count of decoder spawns
-    , threads         :: ![ThreadId]           -- all our threads
     , id3             :: !(Maybe Id3)          -- maybe mp3 id3 info
     , info            :: !(Maybe ByteString)   -- mp3 info
     , status          :: !Status
@@ -118,10 +117,7 @@ sendMpg c = do
     ok <- sendMpg' c
     when (not ok) do
         modifyHS_ \st -> st { minibuffer =
-            case minibuffer st of -- don't overwrite if message already
-                Fast "" _ -> Fast (mp3Tool <> " process not running") (warnings $ uiStyle st)
-                _         -> minibuffer st
-        }
+            Fast (mp3Tool <> " process not running") (warnings $ uiStyle st) }
 
 ------------------------------------------------------------------------
 -- State accessor functions.


### PR DESCRIPTION
*  I see no reason to store thread IDs in the state.  We never use them for anything.
*  With this change, we can move spawning till after the MVar is initially filled.  This doesn't change anything since it waited for it anyway, but maybe it's a simpler model.
*  `playCur` could fail since it checks to see if there's a process, and it might run before mpg123 is spawned.  This race condition was exposed by arising more often when I made the above change.  My solution is an initial polling for up to one second.  If it still fails, `spawns` is set so that a Ready message appears after music initially failed to play.
*  We no longer need to worry that the "not running" warning overwrites the more informative spawn failure warning.  That check was added for the case of initial failure, which is now handled by the polling.