### PR TITLE
Factor two display functions.

### DIFF
--- a/Elements.hs
+++ b/Elements.hs
@@ -73,6 +73,19 @@ progress width = maybe 0 \Frame {..} ->
         ε        = toRational (toEnum 1 `asTypeOf` currentTime) / 2
     in ceiling (curr * fromIntegral (width - 1) / total)
 
+-- | Given a width and size of left, center, and right elements, determine
+-- whether left and right can fit, padding between, and amount of center to show
+fitLCR :: Int -> (Int, Int, Int) -> (Bool, Int, Int, Int)
+fitLCR w (lsz, csz, rsz) =
+    let sides = w - csz
+        side = sides `div` 2
+        gap  = sides - lsz - rsz
+    in if gap >= 2
+        then let gapl = 1 `max` ((side - lsz) `min` (gap - 1))
+             in (True, gapl, gap - gapl, csz)
+        else (False, side `max` 1, (sides - side) `max` ((w-1) `min` 1),
+                0 `max` (csz `min` (w - 2)))
+
 
 -- Modals
 

--- a/Elements.hs
+++ b/Elements.hs
@@ -8,7 +8,6 @@ import Base
 import Decoder (Frame(..))
 import Keyboard (charToKey, historyKeys)
 import State
-import Style (Style(..), StringA(..), defaultSty)
 import Text
 import Paths_hmp3_ng (version)
 
@@ -66,23 +65,13 @@ pTimes w clock
     gap      = spaces distance
     distance = w - 5 - P.length elapsed - P.length left
 
--- | A progress bar
-progressBar :: Style -> Int -> Maybe Frame -> StringA
-progressBar sty sizeW = \case
-    Nothing         -> FancyS [pad, (spaces width, bgs)]
-    Just Frame {..} -> FancyS
-        [pad, (spaces distance, fgs), (spaces (width - distance), bgs)]
-      where
-        total    = curr + toRational timeLeft - ε
-        distance = ceiling (curr * fromIntegral (width - 1) / total)
+-- | Progress out of total
+progress :: Int -> Maybe Frame -> Int
+progress width = maybe 0 \Frame {..} ->
+    let total    = curr + toRational timeLeft - ε
         curr     = toRational currentTime
         ε        = toRational (toEnum 1 `asTypeOf` currentTime) / 2
-  where
-    pad         = ("  ", defaultSty)
-    width       = sizeW - 4
-    Style fg bg = sty
-    bgs         = Style bg bg
-    fgs         = Style fg fg
+    in ceiling (curr * fromIntegral (width - 1) / total)
 
 
 -- Modals

--- a/Elements.hs
+++ b/Elements.hs
@@ -80,11 +80,11 @@ data Fit = Fit { wide :: !Bool, padL :: !Int, padR :: !Int, ctake :: !Int }
 -- whether left and right can fit, padding between, and amount of center to show
 fitLCR :: Int -> (Int, Int, Int) -> Fit
 fitLCR w (lsz, csz, rsz) = if
-    | gap >= 2 -> let gapl = 1 `max` ((side - lsz) `min` (gap - 1))
-                  in Fit True gapl (gap - gapl) csz
-    | True     ->
-        Fit False (side `max` 1) ((sides - side) `max` ((w-1) `min` 1))
-            (0 `max` (csz `min` (w - 2)))
+    | gap >= 2   -> let gapl = 1 `max` ((side - lsz) `min` (gap - 1))
+                    in Fit True gapl (gap - gapl) csz
+    | w-2 >= csz -> Fit False side (sides - side) csz
+    | w > 1      -> Fit False 1 1 (w-2)
+    | True       -> Fit False w 0 0
   where
     sides = w - csz
     side = sides `div` 2

--- a/Elements.hs
+++ b/Elements.hs
@@ -73,18 +73,33 @@ progress width = maybe 0 \Frame {..} ->
         ε        = toRational (toEnum 1 `asTypeOf` currentTime) / 2
     in ceiling (curr * fromIntegral (width - 1) / total)
 
+data Fit = Fit { wide :: !Bool, padL :: !Int, padR :: !Int, ctake :: !Int }
+    deriving stock Show
+
 -- | Given a width and size of left, center, and right elements, determine
 -- whether left and right can fit, padding between, and amount of center to show
-fitLCR :: Int -> (Int, Int, Int) -> (Bool, Int, Int, Int)
-fitLCR w (lsz, csz, rsz) =
-    let sides = w - csz
-        side = sides `div` 2
-        gap  = sides - lsz - rsz
-    in if gap >= 2
-        then let gapl = 1 `max` ((side - lsz) `min` (gap - 1))
-             in (True, gapl, gap - gapl, csz)
-        else (False, side `max` 1, (sides - side) `max` ((w-1) `min` 1),
-                0 `max` (csz `min` (w - 2)))
+fitLCR :: Int -> (Int, Int, Int) -> Fit
+fitLCR w (lsz, csz, rsz) = if
+    | gap >= 2 -> let gapl = 1 `max` ((side - lsz) `min` (gap - 1))
+                  in Fit True gapl (gap - gapl) csz
+    | True     ->
+        Fit False (side `max` 1) ((sides - side) `max` ((w-1) `min` 1))
+            (0 `max` (csz `min` (w - 2)))
+  where
+    sides = w - csz
+    side = sides `div` 2
+    gap  = sides - lsz - rsz
+
+layoutLCR :: Int -> (ByteString, String, ByteString) -> ByteString
+layoutLCR w (left, centerS, right) = mconcat [
+    if fit.wide then left else "",
+    spaces fit.padL,
+    u $ take fit.ctake centerS,
+    spaces fit.padR,
+    if fit.wide then right else ""
+    ]
+  where
+    fit = fitLCR w (P.length left, length centerS, P.length right)
 
 
 -- Modals

--- a/UI.hs
+++ b/UI.hs
@@ -163,11 +163,18 @@ pId3 DD{drawState=st} = maybe (st.music ! st.current).fbase (.str) st.id3
 
 ------------------------------------------------------------------------
 
+-- | Show progress bar.
+progressBar :: DrawData -> StringA
+progressBar (DD w st) = FancyS [
+    ("  ", defaultSty), (spaces x, Style fg fg), (spaces (w'-x), sty)]
+  where
+    w' = w - 4
+    x = El.progress w' st.clock
+    sty@(Style fg _) = st.uiStyle.progress
+
 -- | Two lines showing clock.
 clockLines :: DrawData -> [StringA]
-clockLines (DD w st) = [
-    El.progressBar st.uiStyle.progress w st.clock,
-    Fast (El.pTimes w st.clock) defaultSty ]
+clockLines dd@(DD w st) = [progressBar dd, Fast (El.pTimes w st.clock) defaultSty]
 
 ------------------------------------------------------------------------
 

--- a/UI.hs
+++ b/UI.hs
@@ -208,15 +208,11 @@ playInfo DD{drawState=st} = mconcat
 -- | The top title bar: cursor position + play indicator + uptime + version.
 playTitle :: DrawData -> StringA
 playTitle dd@DD{drawWidth=w, drawState=st} =
-    flip Fast st.uiStyle.titlebar $ mconcat [
-        " ", if lr then left else "", spaces lpad,
-        u $ take ctake centerS,
-        spaces rpad, if lr then right else "", " " ]
+    Fast (El.layoutLCR w (left, centerS, right)) st.uiStyle.titlebar
   where
-    left    = playInfo dd
+    left    = " " <> playInfo dd
     centerS = pState dd ++ ' ' : pMode dd  -- always 6 chars
     right   = st.uptime <> " " <> El.pVersion <> " "
-    (lr, lpad, rpad, ctake) = El.fitLCR w (P.length left + 1, 6, P.length right)
 
 -- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]

--- a/UI.hs
+++ b/UI.hs
@@ -208,19 +208,15 @@ playInfo DD{drawState=st} = mconcat
 -- | The top title bar: cursor position + play indicator + uptime + version.
 playTitle :: DrawData -> StringA
 playTitle dd@DD{drawWidth=w, drawState=st} =
-    flip Fast st.uiStyle.titlebar $ mconcat if gap >= 2
-        then [left, spaces gapl, u centerS, spaces (gap - gapl), right]
-        else if sides >= 2
-            then [spaces side, u centerS, spaces $ sides - side]
-            else [" ", u $ take (w-2) centerS, " "]
+    flip Fast st.uiStyle.titlebar $ mconcat [
+        " ", if lr then left else "", spaces lpad,
+        u $ take ctake centerS,
+        spaces rpad, if lr then right else "", " " ]
   where
-    left    = " " <> playInfo dd
+    left    = playInfo dd
     centerS = pState dd ++ ' ' : pMode dd  -- always 6 chars
     right   = st.uptime <> " " <> El.pVersion <> " "
-    sides   = w - 6
-    side    = sides `div` 2
-    gap     = sides - P.length left - P.length right
-    gapl    = 1 `max` ((side - P.length left) `min` (gap - 1))
+    (lr, lpad, rpad, ctake) = El.fitLCR w (P.length left + 1, 6, P.length right)
 
 -- | The scrolling playlist (visible tracks).
 playList :: Int -> DrawData -> [StringA]

--- a/test/ElementsSpec.hs
+++ b/test/ElementsSpec.hs
@@ -5,7 +5,8 @@ import Test.Tasty.HUnit
 
 import System.Clock (TimeSpec(..))
 
-import Elements (showDuration)
+import Base
+import Elements (showDuration, fitLCR)
 
 tests :: TestTree
 tests = testGroup "Elements"
@@ -35,9 +36,34 @@ tests = testGroup "Elements"
         , testCase "one hour one minute one second"
             $ showDuration True (t 3661)    @?= "1h01m01s"
         ]
+    , testCase "fitLCR" fitTests
     ]
 
 -- Build a TimeSpec from a whole number of seconds.
 t :: Integer -> TimeSpec
 t s = TimeSpec (fromInteger s) 0
+
+fitTests :: Assertion
+fitTests = sequence_ do
+    w <- [1..50]
+    lsz <- [0..20]
+    csz <- [4..8]  -- always 6 currently
+    rsz <- [0..20]
+    let inp = (lsz, csz, rsz)
+    let ans@(lr, padl, padr, ctake) = fitLCR w inp
+    let go as wh = as (wh ++ " " ++ show (w, inp) ++ " -> " ++ show ans)
+    pure do
+        -- Check several invariants.
+        go assertBool "Positive padl" $ padl > 0
+        go assertBool "Positive padr" $ padr > 0 || (ctake == 0 && padr == 0)
+        go assertBool "Nonnegative ctake" $ ctake >= 0
+        go assertEqual "Total width" w $
+            padl + padr + ctake + (if lr then lsz + rsz else 0)
+        go assertEqual "Show iff possible" lr (lsz + csz + rsz + 2 <= w)
+        when (padl > 1 && padr > 1) do
+            go assertEqual "Full center if possible" ctake csz
+            go assertBool "Centered if possible" $
+                let a = padl + (if lr then lsz else 0)
+                    b = padr + (if lr then rsz else 0)
+                in a == b || a + 1 == b
 

--- a/test/ElementsSpec.hs
+++ b/test/ElementsSpec.hs
@@ -3,10 +3,12 @@ module ElementsSpec (tests) where
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Data.ByteString.Char8 qualified as P
 import System.Clock (TimeSpec(..))
 
 import Base
-import Elements (showDuration, fitLCR)
+import Text (displayWidth)
+import Elements (showDuration, fitLCR, layoutLCR, Fit(..))
 
 tests :: TestTree
 tests = testGroup "Elements"
@@ -36,7 +38,7 @@ tests = testGroup "Elements"
         , testCase "one hour one minute one second"
             $ showDuration True (t 3661)    @?= "1h01m01s"
         ]
-    , testCase "fitLCR" fitTests
+    , testCase "Title layout" fitTests
     ]
 
 -- Build a TimeSpec from a whole number of seconds.
@@ -50,20 +52,23 @@ fitTests = sequence_ do
     csz <- [4..8]  -- always 6 currently
     rsz <- [0..20]
     let inp = (lsz, csz, rsz)
-    let ans@(lr, padl, padr, ctake) = fitLCR w inp
+    let ans@Fit{..} = fitLCR w inp
     let go as wh = as (wh ++ " " ++ show (w, inp) ++ " -> " ++ show ans)
     pure do
         -- Check several invariants.
-        go assertBool "Positive padl" $ padl > 0
-        go assertBool "Positive padr" $ padr > 0 || (ctake == 0 && padr == 0)
+        go assertBool "Positive padl" $ padL > 0
+        go assertBool "Positive padr" $ padR > 0 || (ctake == 0 && padR == 0)
         go assertBool "Nonnegative ctake" $ ctake >= 0
         go assertEqual "Total width" w $
-            padl + padr + ctake + (if lr then lsz + rsz else 0)
-        go assertEqual "Show iff possible" lr (lsz + csz + rsz + 2 <= w)
-        when (padl > 1 && padr > 1) do
+            padL + padR + ctake + (if wide then lsz + rsz else 0)
+        go assertEqual "Show iff possible" wide (lsz + csz + rsz + 2 <= w)
+        when (padL > 1 && padR > 1) do
             go assertEqual "Full center if possible" ctake csz
             go assertBool "Centered if possible" $
-                let a = padl + (if lr then lsz else 0)
-                    b = padr + (if lr then rsz else 0)
+                let a = padL + (if wide then lsz else 0)
+                    b = padR + (if wide then rsz else 0)
                 in a == b || a + 1 == b
+        let s = layoutLCR w (P.replicate lsz 'x', replicate csz 'x', P.replicate rsz 'x')
+        assertEqual ("String width: " ++ show inp ++ " -> " ++ show s) w
+            $ displayWidth s
 

--- a/test/ElementsSpec.hs
+++ b/test/ElementsSpec.hs
@@ -30,13 +30,13 @@ tests = testGroup "Elements"
         ]
     , testGroup "showDuration (showSecs=True)"
         [ testCase "thirty seconds"
-            $ showDuration True (t 30)      @?= "30s"
+            $ showDuration True (t 30)     @?= "30s"
         , testCase "one minute exactly appends 00s"
-            $ showDuration True (t 60)      @?= "1m00s"
+            $ showDuration True (t 60)     @?= "1m00s"
         , testCase "one minute thirty seconds"
-            $ showDuration True (t 90)      @?= "1m30s"
+            $ showDuration True (t 90)     @?= "1m30s"
         , testCase "one hour one minute one second"
-            $ showDuration True (t 3661)    @?= "1h01m01s"
+            $ showDuration True (t 3661)   @?= "1h01m01s"
         ]
     , testCase "Title layout" fitTests
     ]
@@ -47,10 +47,10 @@ t s = TimeSpec (fromInteger s) 0
 
 fitTests :: Assertion
 fitTests = sequence_ do
-    w <- [1..50]
-    lsz <- [0..20]
-    csz <- [4..8]  -- always 6 currently
-    rsz <- [0..20]
+    w <- [1..40]
+    lsz <- [0..9]
+    csz <- [0,1,4,5,6,8]  -- always 6 currently
+    rsz <- [0..9]
     let inp = (lsz, csz, rsz)
     let ans@Fit{..} = fitLCR w inp
     let go as wh = as (wh ++ " " ++ show (w, inp) ++ " -> " ++ show ans)


### PR DESCRIPTION
This breaks up the progress bar and play title display elements into two functions: one to calculate parameters, and one to render as display.  This facilitates making the calculations testable.

This is particularly important for the play title display, which had a longstanding bug (~20 years), ferreted out by Fable in #108.  I've added wide-ranging tests for several invariant conditions this element should obey.