### PR TITLE
Improve seeks; add one-minute binds.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -8,11 +8,11 @@
 module Core (
     Options(..),
     start, shutdown,
-    seekLeft, seekRight, upOne, downOne, pause, nextMode, playNext, playPrev,
+    upOne, downOne, pause, nextMode, playNext, playPrev,
     forcePause, putMessage, clearMessage, playCursor, playCur,
     jumpToPlaying, jump, jumpRel, jumpRandom,
     upPage, downPage,
-    seekStart,
+    seek, seekStart,
     blacklist,
     setsModal, closeModal, showHist,
     jumpToMatchDir, jumpToMatchFile,
@@ -221,15 +221,14 @@ shutdown ms = do
 -- Process incoming messages from the decoder.
 
 handleMsg :: Msg -> IO ()
-handleMsg (S i)   = modifyHS_ $ \st -> st { info = Just i }
-handleMsg (I id3) = modifyHS_ $ \st -> st { id3 = Just id3 }
+handleMsg (S i)   = modifyHS_ \st -> st { info = Just i }
+handleMsg (I id3) = modifyHS_ \st -> st { id3 = Just id3 }
 handleMsg (P t)   = do
     modifyHS_ \st -> st
         { status = t
-        , clock = case st.clock of
-            Just f@Frame{ timeLeft } | t == Stopped && timeLeft < 0.1
-                -> Just f { timeLeft = 0 } -- force clock to end if near
-            c   -> c
+        , clock = case st.clock of -- push stopped clock towards end
+            Just fr | t == Stopped -> Just $ adjustFrame 0.1 fr
+            c -> c
         }
     when (t == Stopped) playNext
 handleMsg (F f) = do
@@ -239,22 +238,21 @@ handleMsg (F f) = do
 ------------------------------------------------------------------------
 -- Basic operations
 
--- | Seek backward in song
-seekLeft :: IO ()
-seekLeft = seek \g -> max 0 (g.currentFrame - 400)
-
--- | Seek forward in song
-seekRight :: IO ()
-seekRight = seek \g -> g.currentFrame + min 400 g.framesLeft
+adjustFrame :: Fixed E2 -> Frame -> Frame
+adjustFrame s fr = Frame { elapsed = fr.elapsed + s', left = fr.left - s' }
+    where s' = (s `min` fr.left) `max` (- fr.elapsed)
 
 seekStart :: IO ()
-seekStart = seek $ const 0
+seekStart = seek $ fromIntegral $ minBound @Int
 
--- | Generic seek
-seek :: (Frame -> Int) -> IO ()
-seek fn = do
-    mfr <- getsHS (.clock)
-    whenJust mfr \fr -> sendMpg $ Jump $ fn fr
+-- | Seek in relative seconds
+seek :: Fixed E2 -> IO ()
+seek s = do
+    mss <- modifyHS \st -> case st.clock of
+        Just fr -> let fr' = adjustFrame s fr
+                   in (st { clock = Just fr' }, Just fr'.elapsed)
+        Nothing -> (st, Nothing)
+    whenJust mss $ sendMpg . Jump
 
 ------------------------------------------------------------------------
 

--- a/Decoder.hs
+++ b/Decoder.hs
@@ -21,11 +21,11 @@ mp3Tool = "mpg123"
 ------------------------------------------------------------------------
 -- Send commands to mpg123
 
-data Cmd = Load ByteString | Jump Int | Pause | Quit
+data Cmd = Load ByteString | Jump (Fixed E2) | Pause | Quit
 
 cmdToBS :: Cmd -> ByteString
 cmdToBS (Load f) = "L " <> f
-cmdToBS (Jump i) = "J " <> showInt i -- can be relative with +/-; not used here
+cmdToBS (Jump s) = "J " <> (P.pack . show) s <> "s"
 cmdToBS Pause    = "P"  -- (un)pauses
 cmdToBS Quit     = "Q"
 
@@ -49,14 +49,9 @@ data Id3 = Id3
     } deriving stock (Eq, Show)
 
 -- Frame decoding status updates (once per frame).
--- Current-frame and frames-remaining are integers; current-time and
--- time-remaining floating point numbers with two decimal places.
-data Frame = Frame {
-    currentFrame   :: !Int,
-    framesLeft     :: !Int,
-    currentTime    :: !(Fixed E2),
-    timeLeft       :: !(Fixed E2)
-    } deriving stock (Eq, Show)
+-- Current-time and time-remaining are numbers with two decimal places.
+data Frame = Frame { elapsed :: !(Fixed E2), left :: !(Fixed E2) }
+    deriving stock (Eq, Show)
 
 -- Stop/pause status.
 data Status = Stopped | Paused | Playing
@@ -74,12 +69,10 @@ doP s = do
 -- Frame decoding status updates (once per frame).
 doF :: ByteString -> Maybe Msg
 doF s = do
-    f0 : f1 : f2 : f3 : _ <- pure $ P.split ' ' s
-    currentFrame <- readIntM f0
-    framesLeft   <- readIntM f1
-    currentTime  <- readMaybe $ P.unpack f2
-    timeLeft     <- max 0 <$> readMaybe (P.unpack f3)
-    pure $ F Frame { currentFrame, framesLeft, currentTime, timeLeft }
+    _ : _ : f2 : f3 : _ <- pure $ P.split ' ' s
+    elapsed <- readMaybe $ P.unpack f2
+    left    <- max 0 <$> readMaybe (P.unpack f3)
+    pure $ F Frame { elapsed, left }
 
 -- Info about mp3 file after loading.
 -- Breakdown from mpg123 README.remote (as numbers):

--- a/Elements.hs
+++ b/Elements.hs
@@ -60,17 +60,17 @@ pTimes w clock
     | True                     =
         mconcat $ ["  ", elapsed] ++ [gap <> "-" <> left | distance > 0]
   where
-    elapsed  = showClock (maybe 0 (.currentTime) clock)
-    left     = maybe "?:??.?" (showClock . (.timeLeft)) clock
+    elapsed  = showClock (maybe 0 (.elapsed) clock)
+    left     = maybe "?:??.?" (showClock . (.left)) clock
     gap      = spaces distance
     distance = w - 5 - P.length elapsed - P.length left
 
 -- | Progress out of total
 progress :: Int -> Maybe Frame -> Int
-progress width = maybe 0 \Frame {..} ->
-    let total    = curr + toRational timeLeft - ε
-        curr     = toRational currentTime
-        ε        = toRational (toEnum 1 `asTypeOf` currentTime) / 2
+progress width = maybe 0 \fr ->
+    let total    = curr + toRational fr.left - ε
+        curr     = toRational fr.elapsed
+        ε        = 1 / 200
     in ceiling (curr * fromIntegral (width - 1) / total)
 
 data Fit = Fit { wide :: !Bool, padL :: !Int, padR :: !Int, ctake :: !Int }

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -65,6 +65,8 @@ mainMode = KeyMap \c -> getsHS (.modal) >>= \case
             forcePause *> setsModal (const $ Just ExitModal) $> mainMode
         | c `elem` ['H', ';'] ->
             showHist $> mainMode
+        | c == unkey KeySLeft -> seek (-60) $> mainMode
+        | c == unkey KeySRight -> seek 60 $> mainMode
         | c >= '1' && c <= '9' ->
             jumpRel (fromIntegral (fromEnum c - 48) / 10) $> mainMode
         | True -> sequence_ (M.lookup c keyMap) $> mainMode
@@ -131,8 +133,10 @@ keyTable =
     , ("Jump to start of list",                   [unkey KeyHome,'0'],  jump 0)
     , ("Jump to end of list",                     [unkey KeyEnd,'G'],   jump maxBound)
     , ("Jump to 10%, 20%, 30%, etc., point",      ['1','2','3'],        placeholder)
-    , ("Seek left within song",                   [unkey KeyLeft],      seekLeft)
-    , ("Seek right within song",                  [unkey KeyRight],     seekRight)
+    , ("Seek left 10 seconds; shift for one minute",
+                                                  [unkey KeyLeft],      seek (-10))
+    , ("Seek right 10 seconds; shift for one minute",
+                                                  [unkey KeyRight],     seek 10)
     , ("Toggle pause",                            [' '],                pause)
     , ("Play under cursor",                       ['p'],                playCur)
     , ("Play from cursor",                        ['\n'],               playCursor)

--- a/test/DecoderSpec.hs
+++ b/test/DecoderSpec.hs
@@ -20,8 +20,8 @@ tests = testGroup "Lexer.mpgParser"
         , tc "@P "   $ Left Nothing   -- no payload
         ]
     , testGroup "frame (@F)"
-        [ tc "@F 123 456 12.34 56.78" $ Right (F (Frame 123 456 12.34 56.78))
-        , tc "@F 0 0 0.00 -1.00"      $ Right (F (Frame 0 0 0.00 0))  -- timeLeft clamped
+        [ tc "@F 123 456 12.34 56.78" $ Right (F (Frame 12.34 56.78))
+        , tc "@F 0 0 0.00 -1.00"      $ Right (F (Frame 0.00 0))  -- .left clamped
         , tc "@F 1 2 3.00"            $ Left Nothing   -- too few fields
         , tc "@F a b c d"             $ Left Nothing   -- non-numeric
         ]


### PR DESCRIPTION
Closes #116.

*  We no longer need frame counts at all so they're dropped.
*  Everything is done in seconds.
*  Seeks are made ten seconds exactly instead of the 400-frames approximation.
*  Seeks can be done while paused and work normally.
*  New key binds: shift-left/right-arrows jump by a minute.
*  The new frame adjustment function is used for the stopped case; it has weird edge behavior, but then it did before too.