### PR TITLE
Key binds to resize dir/file columns.

### DIFF
--- a/Core.hs
+++ b/Core.hs
@@ -12,7 +12,7 @@ module Core (
     forcePause, putMessage, clearMessage, playCursor, playCur,
     jumpToPlaying, jump, jumpRel, jumpRandom,
     upPage, downPage,
-    seek, seekStart,
+    seek, seekStart, adjFolderCol,
     blacklist,
     setsModal, closeModal, showHist,
     jumpToMatchDir, jumpToMatchFile,
@@ -89,6 +89,7 @@ start opts (Playlist folders music) = do
         , playHist     = mempty
         , searchHist   = []
         , searchFw     = True
+        , folderCol    = 0.334
         , histSize     = opts.histSize
         , miniFocused  = False
         , status       = Stopped
@@ -227,7 +228,7 @@ handleMsg (P t)   = do
     modifyHS_ \st -> st
         { status = t
         , clock = case st.clock of -- push stopped clock towards end
-            Just fr | t == Stopped -> Just $ adjustFrame 0.1 fr
+            Just fr | t == Stopped -> Just $ adjFrame 0.1 fr
             c -> c
         }
     when (t == Stopped) playNext
@@ -238,8 +239,8 @@ handleMsg (F f) = do
 ------------------------------------------------------------------------
 -- Basic operations
 
-adjustFrame :: Fixed E2 -> Frame -> Frame
-adjustFrame s fr = Frame { elapsed = fr.elapsed + s', left = fr.left - s' }
+adjFrame :: Fixed E2 -> Frame -> Frame
+adjFrame s fr = Frame { elapsed = fr.elapsed + s', left = fr.left - s' }
     where s' = (s `min` fr.left) `max` (- fr.elapsed)
 
 seekStart :: IO ()
@@ -249,10 +250,17 @@ seekStart = seek $ fromIntegral $ minBound @Int
 seek :: Fixed E2 -> IO ()
 seek s = do
     mss <- modifyHS \st -> case st.clock of
-        Just fr -> let fr' = adjustFrame s fr
+        Just fr -> let fr' = adjFrame s fr
                    in (st { clock = Just fr' }, Just fr'.elapsed)
         Nothing -> (st, Nothing)
     whenJust mss $ sendMpg . Jump
+
+adjFolderCol :: Int -> IO ()
+adjFolderCol adj = do
+    (_, sz) <- UI.screenSize
+    modifyHS_ \st -> st { folderCol =
+        let fc' = st.folderCol + fromIntegral adj / fromIntegral sz
+        in (fc' `max` 0) `min` 1 }
 
 ------------------------------------------------------------------------
 

--- a/Keymap.hs
+++ b/Keymap.hs
@@ -65,8 +65,6 @@ mainMode = KeyMap \c -> getsHS (.modal) >>= \case
             forcePause *> setsModal (const $ Just ExitModal) $> mainMode
         | c `elem` ['H', ';'] ->
             showHist $> mainMode
-        | c == unkey KeySLeft -> seek (-60) $> mainMode
-        | c == unkey KeySRight -> seek 60 $> mainMode
         | c >= '1' && c <= '9' ->
             jumpRel (fromIntegral (fromEnum c - 48) / 10) $> mainMode
         | True -> sequence_ (M.lookup c keyMap) $> mainMode
@@ -133,10 +131,7 @@ keyTable =
     , ("Jump to start of list",                   [unkey KeyHome,'0'],  jump 0)
     , ("Jump to end of list",                     [unkey KeyEnd,'G'],   jump maxBound)
     , ("Jump to 10%, 20%, 30%, etc., point",      ['1','2','3'],        placeholder)
-    , ("Seek left 10 seconds; shift for one minute",
-                                                  [unkey KeyLeft],      seek (-10))
-    , ("Seek right 10 seconds; shift for one minute",
-                                                  [unkey KeyRight],     seek 10)
+    , ("Seek 10 seconds; shift for one minute",   [unkey KeyLeft, unkey KeyRight], placeholder)
     , ("Toggle pause",                            [' '],                pause)
     , ("Play under cursor",                       ['p'],                playCur)
     , ("Play from cursor",                        ['\n'],               playCursor)
@@ -159,14 +154,26 @@ keyTable =
     , ("Search backwards for file",               ['?'],                placeholder)
     , ("Search for directory matching regex",     ['\\'],               placeholder)
     , ("Search backwards for directory",          ['|'],                placeholder)
+    , ("Change size of folder and file columns",  ['[', ']'],           placeholder)
     , ("Load config file",                        ['l'],                loadConfig)
     , ("Quit " <> UTF8.fromString package,        ['q'],                placeholder)
     ]
   where placeholder = pure () -- handled separately
 
+-- | Not shown in help menu (or grouped there).
+quietKeys :: [(Char, IO ())]
+quietKeys =
+    [ (unkey KeyLeft,    seek (-10))
+    , (unkey KeyRight,   seek 10)
+    , (unkey KeySLeft,   seek (-60))
+    , (unkey KeySRight,  seek 60)
+    , ('[',              adjFolderCol (-1))
+    , (']',              adjFolderCol 1)
+    ]
+
 -- Compiled dispatch table for normal-mode single-key commands.
 keyMap :: M.Map Char (IO ())
-keyMap = M.fromList [ (c, a) | (_, cs, a) <- keyTable, c <- cs ]
+keyMap = M.fromList $ [ (c, a) | (_, cs, a) <- keyTable, c <- cs ] ++ quietKeys
 
 keysHelp :: [KeysHelp]
 keysHelp = [ (keys, desc) | (desc, keys, _) <- keyTable ]

--- a/State.hs
+++ b/State.hs
@@ -41,6 +41,7 @@ data HState = HState
     , minibuffer      :: !Line                 -- contents of minibuffer
     , modal           :: !(Maybe Modal)        -- modal visible
     , miniFocused     :: !Bool                 -- is the mini buffer focused?
+    , folderCol       :: Float                 -- portion of width for folders
     , mode            :: !Mode
     , uptime          :: !ByteString
     , searchFw        :: !Bool                 -- active search direction

--- a/UI.hs
+++ b/UI.hs
@@ -238,7 +238,7 @@ playList buflen DD{ drawWidth=w, drawState=st } =
 
     list   = [ drawIt . color $ n | n <- zip visible' [0..] ]
 
-    indent = round $ (0.334 :: Float) * fromIntegral w :: Int
+    indent = round $ st.folderCol * fromIntegral (w - 1) :: Int
 
     (sty1, sty2, sty3) = (cs.selected, cs.cursors, cs.combined)
         where cs = st.uiStyle


### PR DESCRIPTION
Closes #78.  As proposed there, `[` and `]` now move the boundary left and righ.

A new `quietKeys` table is added, allowing key binds to not exactly correspond to help rows.  I've started using this to group similar (but not identical actions) into the same row, which I think is better, and will leave more room as features continue to be added.